### PR TITLE
chore(cv-backend-jsfeatnext): bump @webarkit/jsfeat-next to ^0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -464,9 +464,9 @@
       "link": true
     },
     "node_modules/@webarkit/jsfeat-next": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@webarkit/jsfeat-next/-/jsfeat-next-0.15.0.tgz",
-      "integrity": "sha512-r2CSBfyK6oU1Iq1IaBf7rzdWdHjWR2G7XV2QkUzdI2cWRbt/zct7r67+SkRmo/pdqhILuBxwKi++626mGT+YNg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@webarkit/jsfeat-next/-/jsfeat-next-0.16.0.tgz",
+      "integrity": "sha512-O9R0C+Z56aHRDS4Ox8J8jJ12R2DwRZqFjrVt/NvVSAM46xtBezwQNnI4W1nzxo9n5J5hBoUqiTcPKBVKqDXTOQ==",
       "license": "LGPL-3.0-or-later"
     },
     "node_modules/assertion-error": {
@@ -1252,7 +1252,7 @@
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@webarkit/cv-backend-spec": "0.1.0",
-        "@webarkit/jsfeat-next": "^0.15.0"
+        "@webarkit/jsfeat-next": "^0.16.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/packages/cv-backend-jsfeatnext/package.json
+++ b/packages/cv-backend-jsfeatnext/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@webarkit/cv-backend-spec": "0.1.0",
-    "@webarkit/jsfeat-next": "^0.15.0"
+    "@webarkit/jsfeat-next": "^0.16.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/cv-backend-jsfeatnext/test/backend.test.ts
+++ b/packages/cv-backend-jsfeatnext/test/backend.test.ts
@@ -346,10 +346,20 @@ describe("estimateHomography restarts against a bad RANSAC draw (issue #96 follo
     // Internally restarting and keeping the best result is the fix; this test
     // is what would catch a regression back to a single attempt.
     it("never returns a severely degenerate model across many independent runs", () => {
-        // 200 trials, not 25: a single bad draw happens about 1 run in 40 at
-        // RANSAC_RESTARTS = 1 (measured), so a short loop would only catch a
-        // regression back to that about half the time. At 200, the chance of
-        // missing every bad draw is under 1%.
+        // 200 trials, not 25: a short loop would only catch a regression back
+        // to a single-attempt ransac() call about half the time.
+        //
+        // Correction (see webarkit/webarkit#11): this comment used to claim
+        // "the chance of missing every bad draw is under 1%", extrapolated
+        // from a measurement taken at RANSAC_RESTARTS = 1 and never rechecked
+        // once RESTARTS was bumped to 3 (the value actually deployed below).
+        // A worktree A/B test across two jsfeatNext versions, real
+        // (unmocked) Math.random, 15 blocks of 200 trials each at the
+        // deployed RESTARTS = 3, measured 1/3000 trial-level failures and
+        // 1/15 blocks -- i.e. this test itself has an inherent ~6-7% flake
+        // chance on any given run, not under 1%. RESTARTS = 3 does not fully
+        // close the failure mode; #11 tracks jsfeatNext's find_homography()
+        // as a possible structural fix.
         const { src, dst, nInliers } = noisyCorrespondences(95, 0.67, 42);
         for (let trial = 0; trial < 200; trial++) {
             const h = cv.estimateHomography(src, dst, { threshold: 4 });


### PR DESCRIPTION
## Summary

Bumps `@webarkit/jsfeat-next` from `^0.15.0` to `^0.16.0` in `cv-backend-jsfeatnext`.

0.16.0 includes jsfeatNext's RANSAC/homography precision work (issues #185, #186, #187, #188, #189):
- `find_homography` — a linear refit + optional Levenberg-Marquardt polish over the full inlier set (this adapter's `RANSAC_RESTARTS` workaround exists precisely because `ransac()` alone lacked this)
- `homography2d`'s DLT solve now runs in F64 instead of F32
- an injectable RNG for reproducible RANSAC/LMEDS runs

**Not wired into this adapter yet** — `estimateHomography()` still calls `motion_estimator.ransac()` directly, so this PR is the dependency bump only, no behavior change.

## Testing

- `npm test`: 43/43 passing across both workspaces.
- `npm run typecheck`: clean.
- One transient failure in `estimateHomography restarts against a bad RANSAC draw > never returns a severely degenerate model across many independent runs` on the first run — this test is unseeded (relies on the real `Math.random()`). Its comment claimed a ~1% inherent flake rate, but that figure was measured at `RANSAC_RESTARTS = 1` and never rechecked after RESTARTS was bumped to 3. A worktree A/B test across jsfeatNext 0.15.0 and 0.16.0 (real `Math.random`, 15 blocks of 200 trials each at the deployed RESTARTS = 3) found the failure rate identical in both versions — 1/3000 trial-level failures, 1/15 blocks with at least one failure — i.e. an inherent ~6-7% flake chance per run of this test, not under 1%, and not a regression from this bump. The comment is corrected in this PR to reflect the measured number.

## Follow-up (not in this PR)

Now that jsfeatNext ships `find_homography()`, this adapter's `RANSAC_RESTARTS = 3` manual-restart loop and the 1px-tolerance test (loosened in a prior fix specifically because of the precision gap `find_homography` was built to close) could potentially be simplified/tightened, and `find_homography()`'s refit-over-full-inlier-set could plausibly fix the residual ~6-7% flake mode rather than just diluting it. Tracked in webarkit/webarkit#11, which also lays out the A/B methodology to validate that before adopting it. Flagging, not doing here.
