### PR TITLE
fix(cv-backend-jsfeatnext): restart find_homography() instead of raw ransac()

### DIFF
--- a/packages/cv-backend-jsfeatnext/src/jsfeatnext_backend.ts
+++ b/packages/cv-backend-jsfeatnext/src/jsfeatnext_backend.ts
@@ -122,8 +122,8 @@ const SCALE_STEP = Math.cbrt(2);
 const DEFAULT_LEVELS = 6;
 
 /**
- * Independent RANSAC runs per `estimateHomography` call; the best (most
- * inliers) is kept.
+ * Independent `find_homography` runs per `estimateHomography` call; the best
+ * (most inliers) is kept.
  *
  * jsfeatNext's `motion_estimator.ransac` adapts its remaining iteration
  * budget downward the moment it finds an improving hypothesis, using the
@@ -132,15 +132,23 @@ const DEFAULT_LEVELS = 6;
  * hypothesis IS close to the true best — but random sampling occasionally
  * finds a mediocre one first, which shrinks the budget before the real best
  * model has had a fair chance to turn up, and the run ends locked onto the
- * mediocre one.
+ * mediocre one. `find_homography` (jsfeatNext ≥0.16.0) refits over the
+ * winning hypothesis's full inlier set and reclassifies against that refit
+ * model before returning, which recovers much of what a mediocre minimal
+ * sample misses — but not always all of it, so restarts are still needed on
+ * top of it.
  *
- * Measured on the pinball demo images (95 correspondences, ~64 true inliers):
- * a single run found the true model in 38/40 trials, with the 2 misses
- * dropping to single-digit inliers — not a near miss, a different model
- * entirely. Two independent restarts, keeping the better, closed that to
- * 40/40; three gave a comfortable margin (worst observed: 62 of 64). At
- * ~1.4ms per run on that input, three restarts cost single-digit
- * milliseconds — negligible next to a 30fps frame budget, and cheap insurance
+ * Measured with a worktree A/B harness (webarkit/webarkit#11): on the same
+ * adversarial 95-correspondence set used by this file's test (~64 true
+ * inliers), 3000 independent trials at three restarts landed on the true
+ * 64-inlier model EVERY time — 0 failures, versus 1/3000 for plain
+ * `ransac()` restarted the same way (worst observed there: 38 of 64). One or
+ * two `find_homography` restarts are not enough on their own (2.57%/0.07%
+ * measured fail rates against a 70%-of-true-best threshold) — three is where
+ * the mediocre-hypothesis lock-in actually stops showing up, not just gets
+ * rarer. At sub-millisecond added cost per restart (one extra linear refit
+ * and one extra reclassification pass over the point set), three restarts
+ * remain negligible next to a 30fps frame budget, and cheap insurance
  * against a failure mode with no other symptom: `ok` stays `true` and
  * `numInliers` stays plausible, so nothing signals that the fit is wrong
  * short of comparing it against a second attempt.
@@ -488,12 +496,14 @@ export class JsfeatNextBackend implements CvBackend {
         let bestH: Float64Array | null = null;
         let bestMask: Uint8Array | null = null;
 
-        // See RANSAC_RESTARTS: independent runs, keep the one with the most
-        // inliers. `H`/`mask` are reused as scratch across restarts; only the
-        // winner is copied out.
+        // See RANSAC_RESTARTS: independent find_homography runs, keep the one
+        // with the most inliers. `H`/`mask` are reused as scratch across
+        // restarts; only the winner is copied out. refine_iters is 0 because
+        // homography2d does not implement MotionKernel.refine() yet, so the
+        // Levenberg-Marquardt polish step would be a no-op regardless.
         const mask = new jsfeatNext.matrix_t(count, 1, U8C1);
         for (let attempt = 0; attempt < RANSAC_RESTARTS; attempt++) {
-            const ok = jsfeatNext.motion_estimator.ransac(
+            const ok = jsfeatNext.motion_estimator.find_homography(
                 params,
                 jsfeatNext.homography2d,
                 from,
@@ -501,7 +511,9 @@ export class JsfeatNextBackend implements CvBackend {
                 count,
                 H,
                 mask,
-                maxIterations
+                "ransac",
+                maxIterations,
+                0
             );
             if (!ok) continue;
 

--- a/packages/cv-backend-jsfeatnext/test/backend.test.ts
+++ b/packages/cv-backend-jsfeatnext/test/backend.test.ts
@@ -343,23 +343,30 @@ describe("estimateHomography restarts against a bad RANSAC draw (issue #96 follo
     // correspondence set, a SINGLE ransac() call landed on a 4-inlier model
     // once in 40 trials (true best is 64) -- reproducing, down to the same
     // inlier count, the failure first seen on the real pinball demo images.
-    // Internally restarting and keeping the best result is the fix; this test
-    // is what would catch a regression back to a single attempt.
+    // Internally restarting and keeping the best result was the first fix;
+    // `estimateHomography` now restarts `find_homography()` instead of raw
+    // `ransac()` (webarkit/webarkit#11) -- find_homography refits the winning
+    // hypothesis over its full inlier set and reclassifies against that refit
+    // model, which recovers much of what a mediocre minimal sample misses.
+    // This test is what would catch a regression back to raw ransac(), or
+    // back to a single attempt.
     it("never returns a severely degenerate model across many independent runs", () => {
         // 200 trials, not 25: a short loop would only catch a regression back
-        // to a single-attempt ransac() call about half the time.
+        // to a single-attempt call about half the time.
         //
-        // Correction (see webarkit/webarkit#11): this comment used to claim
-        // "the chance of missing every bad draw is under 1%", extrapolated
-        // from a measurement taken at RANSAC_RESTARTS = 1 and never rechecked
-        // once RESTARTS was bumped to 3 (the value actually deployed below).
-        // A worktree A/B test across two jsfeatNext versions, real
-        // (unmocked) Math.random, 15 blocks of 200 trials each at the
-        // deployed RESTARTS = 3, measured 1/3000 trial-level failures and
-        // 1/15 blocks -- i.e. this test itself has an inherent ~6-7% flake
-        // chance on any given run, not under 1%. RESTARTS = 3 does not fully
-        // close the failure mode; #11 tracks jsfeatNext's find_homography()
-        // as a possible structural fix.
+        // History (see webarkit/webarkit#11 for the full methodology): this
+        // comment originally claimed "the chance of missing every bad draw is
+        // under 1%", a figure measured at RANSAC_RESTARTS = 1 and never
+        // rechecked after RESTARTS was bumped to 3. Corrected once already to
+        // "~6-7% flake chance per run", measured for raw ransac() restarted 3
+        // times (1/3000 trial-level failures, 1/15 blocks, worst observed 38
+        // of 64). Since then estimateHomography switched from restarting
+        // ransac() to restarting find_homography() (still RESTARTS = 3): the
+        // same worktree A/B harness measured 0/3000 trial-level failures --
+        // every one of 3000 trials landed on the true 64-inlier model. That is
+        // an empirical result over a large but finite sample, not a proof the
+        // failure mode is impossible, so this test stays at 200 trials as the
+        // regression guard rather than being deleted as unnecessary.
         const { src, dst, nInliers } = noisyCorrespondences(95, 0.67, 42);
         for (let trial = 0; trial < 200; trial++) {
             const h = cv.estimateHomography(src, dst, { threshold: 4 });


### PR DESCRIPTION
## Summary

`estimateHomography()`'s `RANSAC_RESTARTS = 3` loop retried raw `motion_estimator.ransac()`, which can lock onto a mediocre minimal-sample hypothesis with no symptom (`ok` stays `true`, `numInliers` stays plausible, just much smaller than achievable — see #11). This swaps the retried call to jsfeatNext 0.16.0's `find_homography()`, which refits the winning hypothesis over its full inlier set and reclassifies against that refit model before returning.

## Validation (see #11 for full methodology)

Worktree A/B harness, same adversarial 95-correspondence set as the adapter's own flaky-RANSAC test (~64 true inliers), real (unmocked) `Math.random`, 3000 independent trials per approach:

| Approach | Fail rate (< 70% of true best) | Blocks with ≥1 fail (of 15×200) | Min inliers | Mean inliers |
|---|---|---|---|---|
| `ransac` ×1 | 5.30% | 15/15 | -1 (no model) | 60.3 |
| `ransac` ×3 (previous) | 0.03% (1/3000) | 1/15 | 38 | 63.9 |
| `find_homography` ×1 | 2.57% | 15/15 | -1 | 62.5 |
| `find_homography` ×2 | 0.07% (2/3000) | 2/15 | 4 | 64.0 |
| **`find_homography` ×3 (this PR)** | **0.00% (0/3000)** | **0/15** | **64** | **64.0** |

`find_homography` ×3 didn't just dilute the failure mode's probability — every one of 3000 trials landed on the true 64-inlier optimum. Restart count stays at 3: ×1 and ×2 with `find_homography` both measured worse than the previous `ransac` ×3, so `RANSAC_RESTARTS` is not reduced despite the refit doing more per call.

## Testing

- `npm test` (cv-backend-jsfeatnext): 30/30 passing.
- `npm run typecheck`: clean.
- Ran the real vitest suite 15 times in a loop to check the previously-flaky test under the actual harness (not just the standalone A/B script): 15/15 clean. The same loop against the pre-fix code had caught 1 failure in 15.
- Examples manually tested and confirmed working.

Closes #11.