### PR TITLE
docs: add AGENTS.md/CLAUDE.md and agent instruction pointers

### DIFF
--- a/.agents/instructions.md
+++ b/.agents/instructions.md
@@ -1,0 +1,7 @@
+# Agent instructions
+
+The canonical instructions for this repository live in **[`AGENTS.md`](../AGENTS.md)** at the project root.
+
+Please read that file first — it covers the npm-workspaces layout (`packages/cv-backend-spec` is the `CvBackend` contract, `packages/cv-backend-jsfeatnext` is jsfeatNext's implementation of it, in that build order), the exact commands CI runs (`npm install`, `npm run build`, `npm run typecheck`, `npm test`), the Conventional Commits + `dev`-not-`main` PR convention shared with [webarkit/jsfeatNext](https://github.com/webarkit/jsfeatNext) and [webarkit/purecv](https://github.com/webarkit/purecv), and the LGPL license header expected on new source files.
+
+Neither package is published to npm yet (both are pre-1.0) — see the root [README](../README.md) for installing from source and for how this repo fits into the wider webarkit ecosystem (jsfeatNext, WebARKitLib-rs, PureCV, jsartoolkitNFT).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# GitHub Copilot instructions — webarkit
+
+The full guidance is in **[`AGENTS.md`](../AGENTS.md)** (source of truth). Critical points, inlined because Copilot injects this file directly:
+
+- **Central repo for the webarkit org's shared `CvBackend` contract** — `packages/cv-backend-spec` (the interface: `detect`, `describe`, `match`, `estimateHomography`, `poseFromHomography`, optional `filterMatches`) and `packages/cv-backend-jsfeatnext` (jsfeatNext's implementation of it). `examples/` at the repo root exercises the contract directly. Neither package is on npm yet (pre-1.0).
+- **Node** version pinned in `.nvmrc` (currently v24.18.0), npm 9+ for workspaces. Commands, in the order CI runs them: `npm install` → `npm run build` (builds `cv-backend-spec` **then** `cv-backend-jsfeatnext` — that order is load-bearing, npm's default alphabetical order broke it once, see `109caaf`) → `npm run typecheck` (src **and** test) → `npm test` (Vitest).
+- **No Turborepo/Nx** yet — deliberate, revisit once there are more packages.
+- License: LGPL-3.0-or-later; match the existing LGPL header on new files in `packages/*/src`.
+- **Git workflow:** branch off `dev`, PR against **`dev`**, never `main` — same convention as `webarkit/jsfeatNext` and `webarkit/purecv`. Commit messages follow **Conventional Commits** (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`, `ci:`), scoped by package where relevant (`cv-backend-spec`, `cv-backend-jsfeatnext`, `examples`, `ci`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — webarkit
+
+> Canonical instructions for AI coding agents (Claude Code, GitHub Copilot, Cursor, Antigravity, Codex, …).
+> This is the **single source of truth**; `CLAUDE.md`, `.agents/instructions.md`, and `.github/copilot-instructions.md` point here.
+
+## What this project is
+
+**webarkit** is the central repository for the [webarkit](https://github.com/webarkit) organization: the shared **`CvBackend` contract** that lets a high-level WebAR project swap computer-vision backends without rewriting itself, plus the reference backend that implements it. See the root [README](./README.md) for the full "why" and how this fits alongside jsfeatNext, WebARKitLib-rs, PureCV and jsartoolkitNFT — don't duplicate that context here, read it there.
+
+## Environment & commands
+
+- **Node:** version pinned in [`.nvmrc`](./.nvmrc) (currently v24.18.0); `package.json` sets a floor of `>=18`. **Package manager:** npm 9+ (for [workspaces](https://docs.npmjs.com/cli/v9/using-npm/workspaces)).
+- Install: `npm install` — resolves and symlinks both workspace packages, no publish step needed to develop against both together.
+- Build: `npm run build` — builds `@webarkit/cv-backend-spec` **then** `@webarkit/cv-backend-jsfeatnext`, in that order. That order is load-bearing, not incidental: `cv-backend-jsfeatnext`'s build type-checks against the spec's freshly-built `dist/`, and npm's own default (alphabetical) workspace build order broke this once already (see commit `109caaf`) — don't "simplify" this into a bare `npm run build --workspaces`.
+- Typecheck: `npm run typecheck` — `tsc` across `src/` **and** `test/` in every workspace (separate from build, which only checks `src/`).
+- **Test:** `npm test` — Vitest across every workspace.
+- These four are exactly what [`.github/workflows/CI.yml`](./.github/workflows/CI.yml) runs on every push and pull request. Do not claim a change is verified without actually running them.
+
+## Architecture — read this before editing
+
+- npm-workspaces monorepo (`workspaces: ["packages/*"]`), **no Turborepo/Nx yet** — deliberately: with two packages, ordering the two build steps by hand in the root `package.json` script is simpler than standing up a task-graph tool. Revisit once there are several packages, or once builds start depending on each other's outputs in a way plain scripts can't express (see the root README's Layout section for the fuller reasoning, and [turbo.build/repo/docs](https://turbo.build/repo/docs) / [nx.dev](https://nx.dev) if evaluating that later).
+- `packages/cv-backend-spec` — the `CvBackend` **contract only**: types and interfaces, no implementation. Neutral types (typed arrays, plain structs) — no `matrix_t`, no jsfeatNext- or WASM-specific types.
+- `packages/cv-backend-jsfeatnext` — jsfeatNext's implementation of that contract. Depends on **both** the spec and `@webarkit/jsfeat-next` (`^0.16.0`); neither of those depends on it — keep that dependency arrow one-directional.
+- `examples/` — demos live at the repo root, not inside a package, because they exercise the **contract**, not one implementation. See [`examples/README.md`](./examples/README.md).
+- **Neither package is published to npm yet** (both are pre-1.0). Don't write installation instructions elsewhere in the repo that assume `npm install @webarkit/cv-backend-*` works from the public registry — it doesn't yet.
+
+## Conventions
+
+- TypeScript. License: **LGPL-3.0-or-later**. Existing `src/` files in both packages carry an LGPL header — match that template for new files in the same package. This repo does not yet have jsfeatNext's automated header-check script (`scripts/check-license-headers.mjs`); for now this is enforced by review, not CI.
+- Preserve the public `CvBackend` contract surface (`detect`, `describe`, `match`, `estimateHomography`, `poseFromHomography`, optional `filterMatches`) unless a change to `cv-backend-spec` is explicitly intended and reflected in both packages together.
+- Keep the two packages' capability negotiation honest: `capabilities` must never claim something the API can't actually reach (see `cv-backend-jsfeatnext/README.md`'s own notes on `detectors`/`matchFilters` for why this matters).
+- Never commit `.idea/` (already in `.gitignore`).
+
+## Git & contribution workflow
+
+- **Open PRs against `dev` — never `main`.** `dev` is the integration branch; `main` is for stable releases only. This matches the convention already in place in [webarkit/jsfeatNext](https://github.com/webarkit/jsfeatNext) and [webarkit/purecv](https://github.com/webarkit/purecv).
+- **Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):** `type(scope): summary` — e.g. `feat(cv-backend-jsfeatnext): …`, `fix(cv-backend-spec): …`, `docs: …`, `chore: …`, `test: …`, `refactor: …`, `ci: …`. Keep the subject imperative and concise. Common scopes so far: `cv-backend-spec`, `cv-backend-jsfeatnext`, `examples`, `ci` — omit the scope for changes spanning the whole repo (root README, this file, CI config).
+- One branch per task/issue, branched from an up-to-date `dev`.
+
+## Before you make changes
+
+- Small, incremental, reviewable diffs. Match surrounding code style.
+- Keep `npm run build`, `npm run typecheck`, and `npm test` green.
+- If you're touching `estimateHomography` or anything RANSAC-related in `cv-backend-jsfeatnext`, read that package's README section on it first — its current behavior (`find_homography`, `RANSAC_RESTARTS = 3`) was arrived at empirically (see [webarkit/webarkit#11](https://github.com/webarkit/webarkit/issues/11)), not by default choice.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+The canonical, tool-agnostic guidance for this repo lives in **AGENTS.md**. It is imported below — treat it as the source of truth.
+
+@AGENTS.md
+
+## Claude-specific notes
+
+- On this Windows machine, prefer the Bash tool's POSIX shell for git/npm commands in this repo; PowerShell works too but the commands used in commit messages and this repo's own docs assume bash-style quoting.
+- `npm run build` before `npm test` when in doubt: `cv-backend-jsfeatnext`'s tests import from its own `src/`, but its typecheck step (`npm run typecheck`) needs `cv-backend-spec`'s built `dist/` to resolve — a stale or missing sibling build is a common source of confusing type errors that look like real bugs.
+- Root README, and both package READMEs, get read by humans deciding whether to adopt this contract — keep them in sync with reality when behavior changes (see how `cv-backend-jsfeatnext/README.md`'s `estimateHomography` section and version requirement had to be corrected after #11/#12 landed).
+- Don't invent ecosystem facts about sibling repos (WebARKitLib-rs, PureCV, jsartoolkitNFT) from memory — check the actual repo (`gh repo view`, `gh api repos/webarkit/<repo>/readme`) before describing its status, since these move fast and this org iterates on plans across repos.


### PR DESCRIPTION
Adds the same canonical-instructions pattern already used in [webarkit/jsfeatNext](https://github.com/webarkit/jsfeatNext) and [webarkit/purecv](https://github.com/webarkit/purecv): `AGENTS.md` at the root is the single source of truth (environment/commands, architecture, conventions, git & PR workflow), `CLAUDE.md` imports it via `@AGENTS.md` plus a few Claude-specific notes, and `.agents/instructions.md` / `.github/copilot-instructions.md` point other agents at it — the latter inlines the critical points since Copilot injects that file directly rather than following links.

This formalizes what was previously tribal knowledge from this session: branch off `dev` and PR against `dev` (never `main`), Conventional Commits, the load-bearing `cv-backend-spec`-then-`cv-backend-jsfeatnext` build order (broke once via npm's default alphabetical order, see `109caaf`), and the existing-but-unenforced LGPL header convention on source files.

`CONTRIBUTING.md` is intentionally not included — @kalwalt is adding that separately once `dev` merges into `main`.