### PR TITLE
docs: add ADR-0001 and NFT target format spec v0.1

### DIFF
--- a/.claude/agents/nft-reviewer.md
+++ b/.claude/agents/nft-reviewer.md
@@ -1,0 +1,28 @@
+---
+name: nft-reviewer
+description: Read-only reviewer for changes to packages/nft-tracker, crates/wnft-format, the NFT target format and the examples that use them. Checks a diff against ADR-0001, the target format spec and AGENTS.md. Use after implementing a task, before committing.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You review changes in the webarkit monorepo that touch `packages/nft-tracker`, `crates/wnft-format`, the NFT target format, or the examples that use them. You never edit, create or delete files, and you never commit, push or open PRs.
+
+Before reviewing, read:
+- `AGENTS.md`
+- `docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md`
+- `docs/specs/nft-target-format.md`
+
+Then inspect the diff you are given (default: `git diff dev...HEAD`) and check, in this order:
+
+1. **Dependency rules** (ADR-0001, point 2). The only runtime dependency of `nft-tracker` is `@webarkit/cv-backend-spec`. Nothing in `src/` imports jsfeatNext, `cv-backend-jsfeatnext` or any other backend; those may appear only in tests and examples.
+2. **Portability rules** (ADR-0001, point 7). In `src/`: no DOM, timers, `requestAnimationFrame`, workers or camera access; explicit result types instead of exceptions for control flow; fixed-shape data (typed arrays, plain structs); every random choice goes through an injectable RNG; Float64 geometry.
+3. **Spec conformance.** Container framing, checksums, manifest schema, accessor rules, validation order, error and warning codes, resource limits and the canonical writer match `docs/specs/nft-target-format.md` exactly. Every size computation uses checked arithmetic before any allocation. Flag any behaviour the spec does not define: the fix is a spec change, not a silent choice in code.
+4. **Contract usage.** Capability negotiation is respected, with no silent descriptor substitution. No changes to `packages/cv-backend-spec` unless the task explicitly says so.
+5. **Tests.** New behaviour is covered. Fixtures are produced by a committed deterministic script, never hand-edited. No tolerance was loosened without a written justification.
+6. **Repo conventions.** LGPL headers on new `src/` files; Conventional Commits; `nft-tracker` built after `cv-backend-jsfeatnext` in the root `package.json`.
+
+7. **Rust crate** (if `crates/` is touched). Implemented from the specification, not translated line by line from the TS codec; no `unsafe`; no panic reachable from `decode` on untrusted input (no `unwrap`, `expect`, unchecked indexing or unchecked arithmetic on sizes); unaligned data read with `from_le_bytes`, never pointer casts; the `no_std` build still compiles; fixtures are consumed, never generated, by Rust.
+
+Run `npm run build`, `npm run typecheck` and `npm test`; if `crates/` is touched, also `cargo fmt --check`, `cargo clippy -- -D warnings` and `cargo test`. Report the outcome of each.
+
+Report findings grouped as **Blocking**, **Should fix** and **Nit**, each with `file:line` and a concrete suggestion. If nothing is blocking, say so explicitly in the first line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,16 @@
 
 ## Conventions
 
+- **Language:** every repository artifact — code, comments, commit messages, PR titles and bodies, issues, docs — is written in English, whatever language the conversation with the agent uses.
 - TypeScript. License: **LGPL-3.0-or-later**. Existing `src/` files in both packages carry an LGPL header — match that template for new files in the same package. This repo does not yet have jsfeatNext's automated header-check script (`scripts/check-license-headers.mjs`); for now this is enforced by review, not CI.
 - Preserve the public `CvBackend` contract surface (`detect`, `describe`, `match`, `estimateHomography`, `poseFromHomography`, optional `filterMatches`) unless a change to `cv-backend-spec` is explicitly intended and reflected in both packages together.
 - Keep the two packages' capability negotiation honest: `capabilities` must never claim something the API can't actually reach (see `cv-backend-jsfeatnext/README.md`'s own notes on `detectors`/`matchFilters` for why this matters).
 - Never commit `.idea/` (already in `.gitignore`).
+
+## Design records
+
+- Architecture decisions live in [`docs/adr/`](./docs/adr/); the formats and protocols they decide are specified in [`docs/specs/`](./docs/specs/). Read the relevant record before changing anything it covers.
+- **An accepted ADR is not edited — it is superseded by a new one.** To change an accepted decision, write the next ADR, state what it supersedes, and mark the old one `Superseded by ADR-XXXX`. Only ADRs still in `Proposed` are edited in place.
 
 ## Git & contribution workflow
 

--- a/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
+++ b/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
@@ -31,7 +31,7 @@ Forces at play:
 2. **Dependencies.** The only runtime dependency is `@webarkit/cv-backend-spec`. Backend packages (`cv-backend-jsfeatnext` today, the WebARKitLib-rs adapter later) are **devDependencies**, used by tests and examples. The backend is injected by the caller:
 
    ```ts
-   const cv = await createJsfeatBackend();      // later: the WebARKitLib-rs adapter
+   const cv = await createJsfeatNextBackend();  // later: the WebARKitLib-rs adapter
    const tracker = new NftTracker(cv, target, K);
    ```
 

--- a/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
+++ b/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
@@ -1,0 +1,148 @@
+# ADR-0001: NFT tracker — TypeScript reference above `CvBackend`, measured Rust port, shared target format
+
+**Status:** Accepted
+**Date:** 2026-09-10
+**Deciders:** @kalwalt
+
+## Context
+
+WebARKit needs a natural-feature-tracking (NFT) layer for planar image targets: find a trained image in the camera feed, keep tracking it frame to frame with a stable pose, and recover when it is lost.
+
+Where the org stands today:
+
+- `@webarkit/cv-backend-spec` defines a **stateless, synchronous** CV contract (`detect`, `describe`, `match`, optional `filterMatches`, `estimateHomography`, `poseFromHomography`) with capability negotiation. Its header comment explicitly places target training, the tracking loop, pose refinement, validation and temporal filtering **above** the contract, written once against it.
+- `@webarkit/cv-backend-jsfeatnext` implements the contract end to end. Today it has the FAST detector, ORB descriptors, ratio/cross-check matching and RANSAC homography with restarts; it has no match filter yet. It is the org's numeric oracle.
+- The webcam example runs the pipeline **stateless per tick**: every frame is detected from scratch and nothing carries over. That is repeated detection, not tracking — every frame pays full detection cost and produces an independent, noisy pose estimate.
+- Per-level target matching (`buildLevelIndex` + `matchPerLevel` in `examples/js/pinball-shared.mjs`) finds roughly 2.5× the matches of pooled matching. This is high-level logic that currently lives in an example.
+- **WebARKitLib-rs, with PureCV as its CV layer, is the planned production WASM backend.** It does not speak `CvBackend` yet; an adapter package is expected, the way `cv-backend-jsfeatnext` wraps jsfeatNext. WebARKitLib-rs also contains its own port of the ARToolKit NFT/KPM engine, kept for jsartoolkitNFT marker compatibility; this ADR does not touch it.
+- The org's established porting practice is reference-first — OpenCV → jsfeatNext (TS) → PureCV (Rust) — with the TS implementation acting as the oracle for the Rust one.
+
+Forces at play:
+
+- The tracker is stateful and algorithmically dense, and it will change a lot while it is tuned. Iteration speed and debuggability matter more than raw speed at first.
+- It should run on every backend that implements the contract, not on one.
+- Real-time budget on mid-range mobile: 33 ms per frame at 30 fps, shared with camera acquisition and rendering.
+- A target trained once must be usable by every implementation of the tracker, now and after a possible port.
+
+## Decision
+
+1. **Placement.** A new workspace package, `packages/nft-tracker` (package name TBD, e.g. `@webarkit/nft-tracker`), implements the tracker in TypeScript, above the contract.
+
+2. **Dependencies.** The only runtime dependency is `@webarkit/cv-backend-spec`. Backend packages (`cv-backend-jsfeatnext` today, the WebARKitLib-rs adapter later) are **devDependencies**, used by tests and examples. The backend is injected by the caller:
+
+   ```ts
+   const cv = await createJsfeatBackend();      // later: the WebARKitLib-rs adapter
+   const tracker = new NftTracker(cv, target, K);
+   ```
+
+   The dependency arrow stays one-directional: nothing depends on `nft-tracker` except applications and examples.
+
+3. **Division of labour.** Work proportional to the pixels of a whole frame goes through the backend (detection, description, matching, homography estimation). Work on tens of points or on small patches lives in the tracker (patch tracking, pose from homography with ambiguity resolution, temporal filtering, the state machine). If profiling shows a tracker-side step is too slow, it moves down into the contract as a new **optional** method with a capability flag — the pattern already used for `filterMatches`. Expected candidates, in order: the frame pyramid for tracking, synthetic-view warping in the target compiler, patch alignment.
+
+4. **TypeScript is the reference implementation.** If a Rust port (inside WebARKitLib-rs) ever happens, it is a *port of the TS reference*, validated against it through shared fixtures. Algorithm changes land in TS first and are then ported. The two implementations never evolve independently.
+
+5. **The Rust port is conditional on a measured criterion, not scheduled.** It is triggered when, on the reference device (TBD — a mid-range Android phone), over a recorded test sequence, **either**:
+
+   - the JS↔WASM boundary overhead (marshalling and copies across the contract) exceeds **10% of the frame budget at p95** (> 3.3 ms per frame), **or**
+   - tracker-side TypeScript compute in the tracking state exceeds **8 ms per frame at p95**,
+
+   **and** moving individual steps into the backend (point 3) has not brought it back under the threshold. The thresholds are proposals, to be confirmed or revised after the first measurements.
+
+6. **The target format is shared from day one.** Trained targets use a binary, versioned, language-neutral format, specified in [`docs/specs/nft-target-format.md`](../specs/nft-target-format.md) before any code reads or writes it. The format — not the TS source — is the contract between the TS and Rust implementations.
+
+7. **Portability rules for the TS code**, so that a port stays cheap:
+
+   - **Pure core.** Input: a `GrayImage` and a timestamp. Output: a pose result. No DOM, timers, `requestAnimationFrame`, workers or camera access inside the package; the application owns the loop.
+   - **Explicit result types** (`{ ok, ... }`, as `HomographyResult` already does). Exceptions are reserved for contract violations, never used for control flow.
+   - **Fixed-shape data.** Typed arrays and plain structs; no dynamic property bags.
+   - **Determinism.** Every random choice goes through an injectable RNG (as jsfeatNext's RANSAC already allows), so fixtures are reproducible.
+   - **Float64 geometry**, as the contract requires.
+   - **Fixtures are data files** (frame sequences, expected homographies and poses) in a shared directory, readable by both `vitest` and `cargo test`.
+
+## Options considered
+
+### Option A — TS reference above the contract, conditional Rust port (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Complexity | Medium |
+| Backends supported | Every contract implementation |
+| Debuggability | High — readable TS, jsfeatNext as oracle |
+| Performance | Unknown until measured; tracking-state frames make no backend calls |
+| Fit with existing practice | Same shape as OpenCV → jsfeatNext → PureCV |
+
+**Pros:** First real consumer of the contract, so it validates the contract's design. Works today on jsfeatNext. No commitment to Rust until data justifies it.
+**Cons:** Detection-state frames make several boundary crossings on a WASM backend. If the port is triggered, two implementations must be kept aligned under the reference/port discipline.
+
+### Option B — Tracker in Rust, inside WebARKitLib-rs only
+
+| Dimension | Assessment |
+|---|---|
+| Complexity | High |
+| Backends supported | WebARKitLib-rs only |
+| Debuggability | Low–medium |
+| Performance | Best — one boundary crossing per frame |
+| Fit with existing practice | Skips the TS reference step |
+
+**Pros:** Maximum performance; a single implementation.
+**Cons:** The contract becomes irrelevant for NFT, which is its main use case. No jsfeatNext path and no oracle. Slow iteration during the tuning-heavy phase.
+
+### Option C — TS and Rust developed in parallel, independently
+
+**Pros:** Both exist early.
+**Cons:** Two stateful implementations of the same algorithm drift apart, and effort goes into reconciling them rather than into tracking quality. **Rejected.**
+
+### Option D — Stateful tracking primitives inside the contract
+
+**Cons:** Breaks the stateless, synchronous contract that both backends and the negotiation rules are built on. Stateless optional primitives (point 3) already cover the performance need. **Rejected.**
+
+## Trade-off analysis
+
+The deciding trade-off is **iteration speed and backend neutrality now** versus **peak performance later**. Option A does not give up peak performance permanently: point 3 moves hot steps into the backend, and point 5 keeps a full port available. Option B gives up backend neutrality permanently.
+
+The expected cost of Option A on a WASM backend is small but unmeasured: tracking-state frames make no backend call at all, while detection-state frames make about five calls with frame-sized copies. Point 5 exists precisely to replace this expectation with a number.
+
+## Consequences
+
+**Easier:**
+
+- NFT works on jsfeatNext immediately, and on WebARKitLib-rs as soon as its adapter exists, with no tracker changes.
+- New descriptors (TEBLID) and filters (GMS) are picked up through capability negotiation, with no tracker changes.
+- The contract gets a real consumer, which surfaces its gaps early.
+
+**Harder:**
+
+- If the port is triggered, two implementations must be kept aligned.
+- The target format has to be designed carefully up front.
+
+**Contract gaps surfaced by this ADR** (to be filed as separate `cv-backend-spec` issues):
+
+- **`Keypoint.level` is ambiguous across backends.** A level index only has meaning together with the pyramid scale step that produced it, and that step is an internal constant of each backend (`Math.cbrt(2)` in `cv-backend-jsfeatnext`), not part of the contract. Passing stored keypoints to another backend's `describe` — for example to re-describe a target on the runtime backend — silently computes descriptors at the wrong scale if the steps differ. Proposal: declare the step (e.g. as a capability). The target format already records it.
+- **Same `DescriptorKind`, different bits.** Two backends that both declare `"orb"` (or `"teblid"`) may produce different bits because of the sampling pattern, the smoothing or the orientation quantisation. The `kind` guard from jsfeatNext#128 cannot see this. Proposal: a cross-backend descriptor conformance test on a fixture image, or a variant/version field on `Descriptors`.
+- **No k-nearest matching.** `match` exposes the best match or an internal ratio test, but not the k nearest neighbours. Multi-view target descriptors need a ratio test where the second-best candidate belongs to a *different keypoint*, which the tracker cannot do without the neighbours.
+- **Missing selectors.** `DetectOptions` has no detector selector and no spatial-distribution control (grid or bucketing); `RansacOptions` has no estimator selector (e.g. PROSAC). All are non-breaking additions.
+- **Single pose.** `poseFromHomography` returns one pose. Planar ambiguity resolution (IPPE, two candidates) is done in the tracker for now.
+
+**To revisit:**
+
+- The point 5 thresholds, after the first measurements on the reference device.
+- Whether `nft-tracker` should be split (e.g. the target compiler as its own package) once it grows.
+
+## Action items
+
+1. [x] Review and accept this ADR; add a pointer to `docs/adr/` in `AGENTS.md`.
+2. [x] Review and accept [`docs/specs/nft-target-format.md`](../specs/nft-target-format.md) (v0).
+3. [ ] Scaffold `packages/nft-tracker` (package.json, tsconfig, vitest, LGPL headers) and append it to the root `build` script **after** the spec — the build order is load-bearing.
+4. [ ] **M1 — parity:** a detection-only `NftTracker` equivalent to the webcam demo; move `buildLevelIndex` / `matchPerLevel` from `examples/js/pinball-shared.mjs` into the package, with tests.
+5. [ ] File the contract issues listed under "Contract gaps".
+6. [ ] Pick the reference device; record baseline numbers for the stateless demo.
+7. [ ] **M2** patch tracker + state machine → **M3** IPPE + One Euro filter → **M4** target compiler with synthetic views. Each milestone is measured against the previous one on the same recorded sequences.
+
+## References
+
+- `packages/cv-backend-spec/src/cv_backend.ts` — the contract and its layering statement.
+- `examples/README.md` — per-level matching, the stateless webcam demo, the single-scale live-frame limitation.
+- jsfeatNext#96 (contract), jsfeatNext#128 (descriptor selection and capabilities), jsfeatNext#129 (`filterMatches`); webarkit/webarkit#11 (RANSAC restarts).
+- D. Wagner, G. Reitmayr, A. Mulloni, T. Drummond, D. Schmalstieg, *Real-Time Detection and Tracking for Augmented Reality on Mobile Phones*, IEEE TVCG 16(3), 2010 — the detection + patch-tracker architecture.
+- F. Göttl, P. Gagel, J. Grubert, *Efficient Pose Tracking from Natural Features in Standard Web Browsers*, Web3D 2018 (arXiv:1804.08424) — the same architecture in WebAssembly.
+- T. Collins, A. Bartoli, *Infinitesimal Plane-Based Pose Estimation*, IJCV 109(3), 2014.

--- a/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
+++ b/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
@@ -50,6 +50,8 @@ Forces at play:
 
 6. **The target format is shared from day one.** Trained targets use a binary, versioned, language-neutral format, specified in [`docs/specs/nft-target-format.md`](../specs/nft-target-format.md) before any code reads or writes it. The format — not the TS source — is the contract between the TS and Rust implementations.
 
+   The format has two codecs. The TypeScript codec in `packages/nft-tracker` is the one the tracker requires. A Rust codec, `crates/wnft-format` in this monorepo, is written from this specification — not ported from the TypeScript source — so that two independent implementations expose ambiguities in the specification, and so that WebARKitLib-rs and Rust tooling can read targets. It is a stateless, fully specified component, so it is neither the tracker port of point 5 nor Option C: points 4 and 5 govern the tracker only. Both codecs consume the same fixtures, which only the TypeScript generator produces.
+
 7. **Portability rules for the TS code**, so that a port stays cheap:
 
    - **Pure core.** Input: a `GrayImage` and a timestamp. Output: a pose result. No DOM, timers, `requestAnimationFrame`, workers or camera access inside the package; the application owns the loop.
@@ -114,6 +116,7 @@ The expected cost of Option A on a WASM backend is small but unmeasured: trackin
 
 - If the port is triggered, two implementations must be kept aligned.
 - The target format has to be designed carefully up front.
+- The monorepo gains a Cargo workspace and a Rust job in CI, which raises the prerequisites for contributors touching the format.
 
 **Contract gaps surfaced by this ADR** (to be filed as separate `cv-backend-spec` issues):
 

--- a/docs/specs/nft-target-format.md
+++ b/docs/specs/nft-target-format.md
@@ -1,0 +1,473 @@
+# NFT target format — v0.1
+
+**Status:** Accepted (format 0.1). The format version is `0.1`: while the major is `0`, every minor may break compatibility (§7).
+**Decided by:** [ADR-0001](../adr/0001-nft-tracker-ts-reference-above-cvbackend.md), point 6.
+**Implementations:** `packages/nft-tracker/src/target/format` (TypeScript, which also hosts the fixture generator) and `crates/wnft-format` (Rust). The two are peers: this specification is the source of truth, and two independent implementations exist to expose its ambiguities.
+
+The key words MUST, MUST NOT, SHOULD and MAY are used as in RFC 2119.
+
+## 1. Purpose
+
+A trained NFT target is everything the tracker needs to find and follow one planar image: keypoints, descriptors, pyramid geometry, tracking patches and physical size. This document defines the file that stores it, with the extension `.wnft`.
+
+The format is the contract between tracker implementations. A file written by one implementation MUST decode to the same values in any other.
+
+**Non-goals:**
+- Compatibility with ARToolKit `.iset` / `.fset` / `.fset3` files.
+- Compression inside the file. Serve it with HTTP `gzip`/`br` instead.
+- Storing backend-internal structures (`matrix_t`, KPM trees, search indices). Indices are built at load time.
+
+A `.wnft` file can be delivered on its own, or embedded unchanged in a WASM module or a bundle (Rust `include_bytes!`, Emscripten `--embed-file`). This specification defines only the bytes; §3 covers alignment when a file is embedded.
+
+## 2. Design at a glance
+
+The format has two layers, following the GLB container of glTF 2.0:
+
+```
+┌ container header ┐┌ JSON chunk ─────────┐┌ BIN chunk ──────────────────────┐
+  magic, version,     manifest: structure,   bulk arrays: coordinates,
+  total length        meaning, parameters    descriptors, patches, pixels
+```
+
+- **Container** (§4): framing only — magic, container version, lengths, CRC-32 checksums. It is expected to change almost never.
+- **Manifest** (§5): a JSON object describing everything in the file — what each array is, which descriptor families are present, their parameters. It carries the **format version** and evolves with this specification.
+- **Data chunk:** every bulk array, aligned so that readers can view it without copying. Arrays are located through **accessors** in the manifest (offset, element count, element type), never through offsets computed from other fields.
+
+Two properties follow from this split:
+
+- **Adding something never shifts existing bytes.** A new field is a new manifest key; a new array is a new accessor. Old readers ignore both (§7).
+- **Versioning happens at two layers, and each version governs only its own layer** (§7). This is not duplication: a reader must be able to reject a container it cannot frame *before* it looks for the manifest, and it can only read the format version *after* framing.
+
+## 3. Conventions
+
+**Byte order.** All multi-byte values are little-endian. Every platform WebARKit targets is little-endian, so readers MAY view arrays directly. TS readers SHOULD assert this once at load time:
+
+```ts
+const LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+```
+
+**Alignment.** Chunk data starts at a file offset that is a multiple of 8, and every accessor's offset is a multiple of its element size (the canonical writer uses 8). All padding is defined in §4.
+
+When a file is not at an 8-aligned address — for example, a `.wnft` stored inside a larger `ArrayBuffer`, or embedded with Rust `include_bytes!`, which only guarantees 1-byte alignment — views may be impossible. JS typed arrays require the byte offset to be a multiple of the element size. Readers MUST detect this and fall back to copying the affected arrays. They MUST NOT read misaligned data through a view.
+
+**Pixel coordinates.** Integer coordinates are pixel centres, so a FAST corner at column 10 has `x = 10`. All keypoint and patch positions are stored in **level-0 coordinates**, i.e. pixels of the full-resolution reference image.
+
+**Level-to-level-0 mapping.** A point found at `x_l` on level `l` is stored as
+
+```
+x0 = x_l / s_l,   where s_l = scale_step^(-l)
+```
+
+with **no half-pixel correction**. This matches `cv-backend-jsfeatnext` (`x: k.x / scale`) and OpenCV's ORB (decision D2).
+
+**Model plane.** The target lies on the plane `Z = 0`. Units are millimetres, the origin is at level-0 pixel `(0, 0)`, `+X` points right and `+Y` points down, matching the image axes (decision D1):
+
+```
+X_mm = x0 · physicalWidthMm  / widthPx
+Y_mm = y0 · physicalHeightMm / heightPx
+```
+
+With these axes, the pose from `poseFromHomography` follows OpenCV conventions, as the contract specifies. Converting to renderer conventions (GL, Y-up) and centring content on the target are the job of the tracker API and the renderer adapter, never of the file. If the physical size is unknown (`physicalSizeMm: null`), model-plane units are level-0 pixels.
+
+**Angles.** Stored in radians exactly as the detector produced them. Readers MUST NOT assume a range; angles are periodic.
+
+## 4. Container
+
+### 4.1 Header
+
+| Offset | Size | Type | Field | Notes |
+|---|---|---|---|---|
+| 0 | 4 | `u8[4]` | `magic` | `"WKNF"` = `57 4B 4E 46` |
+| 4 | 2 | `u16` | `container_major` | `1` |
+| 6 | 2 | `u16` | `container_minor` | `0` |
+| 8 | 4 | `u32` | `total_length` | Length of the whole file, header included |
+| 12 | 4 | `u32` | `flags` | Reserved. MUST be `0` |
+
+`total_length` MUST equal the length of the buffer the reader is given. This catches truncated downloads before anything else is read.
+
+### 4.2 Chunks
+
+Chunks follow the header back to back until `total_length`. Each chunk has a 16-byte header:
+
+| Offset | Size | Type | Field | Notes |
+|---|---|---|---|---|
+| 0 | 4 | `u32` | `chunk_length` | Bytes of chunk data, **excluding** padding |
+| 4 | 4 | `u8[4]` | `chunk_type` | `"JSON"` or `"BIN\0"`; others reserved |
+| 8 | 4 | `u32` | `crc32` | CRC-32 of the chunk data, excluding padding |
+| 12 | 4 | `u32` | reserved | MUST be `0` |
+| 16 | `chunk_length` | — | data | |
+
+After the data, the chunk is padded to a multiple of 8 bytes. The `JSON` chunk is padded with spaces (`0x20`); every other chunk is padded with zeros. With a 16-byte file header and 16-byte chunk headers, every chunk's data therefore starts at an 8-aligned offset.
+
+**Chunk rules:**
+- The first chunk MUST be `JSON`. There is exactly one.
+- The second chunk, if present, MUST be `BIN\0`. There is at most one. It MUST be present if the manifest declares any accessor.
+- Any chunk after these is ignored by readers that do not know its type (warning `UNKNOWN_CHUNK_SKIPPED`). This leaves room for future container minors.
+
+**Checksum.** `crc32` is CRC-32/ISO-HDLC — polynomial `0x04C11DB7` (reflected `0xEDB88320`), initial value and final XOR `0xFFFFFFFF` — the same as zlib, PNG and Rust's `crc32fast`. Test vector: the ASCII bytes `123456789` give `0xCBF43926`.
+
+CRC-32 detects **accidental** corruption: a truncated or damaged download, a broken cache entry, a bad copy. It does not detect deliberate tampering, because anyone who modifies the data can recompute it. Protection against tampering comes from the transport (HTTPS, Subresource Integrity), not from this format.
+
+## 5. Manifest
+
+The `JSON` chunk holds one JSON object: UTF-8, no BOM.
+
+### 5.1 Top level
+
+```json
+{
+  "format": { "version": "0.1", "generator": "@webarkit/nft-tracker 0.1.0" },
+  "extensionsUsed": [],
+  "extensionsRequired": [],
+  "meta": { },
+  "pyramid": { },
+  "keypoints": { },
+  "descriptorSets": [ ],
+  "patches": { },
+  "referenceImage": { },
+  "info": { },
+  "accessors": [ ]
+}
+```
+
+| Key | Required | Content |
+|---|---|---|
+| `format` | yes | `version` as `"MAJOR.MINOR"` (§7); `generator` free text, optional |
+| `extensionsUsed` | no | Names of extensions present in the file |
+| `extensionsRequired` | no | Subset of `extensionsUsed` a reader MUST understand to read the file correctly |
+| `meta` | yes | §5.3 |
+| `pyramid` | yes | §5.4 |
+| `keypoints` | yes | §5.5 |
+| `descriptorSets` | yes | §5.6, at least one entry |
+| `patches` | no | §5.7 |
+| `referenceImage` | no | §5.8 |
+| `info` | no | §5.9 |
+| `accessors` | yes | §5.2 |
+
+**Unknown keys.** Readers MUST ignore keys they do not know, at every level. Writers MUST NOT use a new key to change the meaning of existing data (§7).
+
+**Extensions.** An extension has a name with the `WKNF_` prefix (e.g. `WKNF_multiview`) and may attach data to any object under an `"extensions": { "WKNF_name": { … } }` key, as in glTF.
+
+### 5.2 Accessors
+
+Every array lives in the `BIN` chunk and is described by an accessor. Manifest fields refer to accessors by their index in `accessors`.
+
+```json
+{ "offset": 0, "count": 1000, "type": "f32" }
+```
+
+| Field | Content |
+|---|---|
+| `offset` | Byte offset from the start of the `BIN` chunk data. MUST be a multiple of the element size |
+| `count` | Number of elements (not bytes) |
+| `type` | `"u8"`, `"u16"`, `"u32"` or `"f32"` |
+
+Accessor rules:
+- `offset + count × size(type)` MUST be `≤` the `BIN` chunk length, computed with checked arithmetic (§6.1).
+- Accessors MUST NOT overlap. Each array owns its bytes.
+- Every field that references an accessor fixes the expected `type` and `count`. A mismatch is `BAD_LAYOUT`.
+- Accessors that no known field references are allowed and ignored; they may belong to an extension.
+
+### 5.3 `meta`
+
+```json
+{ "widthPx": 1024, "heightPx": 768, "physicalSizeMm": [210, 157.5] }
+```
+
+`widthPx` and `heightPx` MUST equal `pyramid.levelSizes[0]`. `physicalSizeMm` is `[width, height]` in millimetres, both `> 0`, or `null` if unknown.
+
+### 5.4 `pyramid`
+
+```json
+{ "scaleStep": 1.2599210498948732, "levelSizes": [[1024, 768], [812, 609], [645, 484]] }
+```
+
+- `scaleStep` is the size ratio between consecutive levels, e.g. `2^(1/3)`.
+- The number of levels `L` is `levelSizes.length`, at least 1.
+- `levelSizes` are authoritative. Implementations round differently — `cv-backend-jsfeatnext` uses `(w * s) | 0` — so sizes are recorded as produced, not recomputed.
+
+`scaleStep` is what gives meaning to a keypoint's `level`. The contract carries the level but not the step (ADR-0001, contract gaps).
+
+### 5.5 `keypoints`
+
+```json
+{
+  "count": 1000,
+  "detector": { "kind": "fast", "params": { "threshold": 20 } },
+  "levelStart": 0, "x": 1, "y": 2, "angle": 3, "score": 4, "size": 5, "level": 6
+}
+```
+
+| Field | Accessor type, count | Content |
+|---|---|---|
+| `count` | — | `N` |
+| `detector` | — | `kind` (a `DetectorKind` string) and free-form `params`. Informative, except where a descriptor's parameters depend on the detector (§5.6) |
+| `levelStart` | `u32`, `L + 1` | Keypoints of level `l` are the indices `[levelStart[l], levelStart[l+1])`; `levelStart[L] = N` |
+| `x`, `y` | `f32`, `N` | Level-0 coordinates (§3) |
+| `angle` | `f32`, `N` | Radians |
+| `score` | `f32`, `N` | Detector response |
+| `size` | `f32`, `N` | Optional. Diameter, in level-0 pixels, of the region the descriptor sampled. Absent means unknown |
+| `level` | `u8`, `N` | Pyramid level. MUST agree with `levelStart` |
+
+Keypoints MUST be sorted by level, ascending. `f32` is used rather than `f64` because it halves the arrays and its precision at 4096 px (~0.0005 px) is far below detector accuracy. Readers widen to `Float64` when building the contract's `PointArray`.
+
+These fields map directly onto the contract's `Keypoint` (`x`, `y`, `score`, `angle`, `level`).
+
+### 5.6 `descriptorSets`
+
+Each entry is one descriptor set:
+
+```json
+{
+  "kind": "teblid",
+  "norm": "hamming",
+  "elementType": "bits",
+  "dimensions": 256,
+  "bytesPerDescriptor": 32,
+  "producer": "purecv",
+  "params": { "scaleFactor": 1.0 },
+  "count": 1000,
+  "levelStart": 7, "kpIndex": 8, "data": 9
+}
+```
+
+| Field | Content |
+|---|---|
+| `kind` | A `DescriptorKind` string, e.g. `"orb"`, `"freak"`, `"teblid"` |
+| `norm` | Distance: `"hamming"`, `"hamming2"`, `"l2"`, … |
+| `elementType` | `"bits"` (packed binary), `"u8"` or `"f32"` |
+| `dimensions` | Number of bits for `"bits"`, number of elements otherwise |
+| `bytesPerDescriptor` | MUST equal `dimensions / 8` for `"bits"` (`dimensions` a multiple of 8), `dimensions` for `"u8"`, `4 × dimensions` for `"f32"` |
+| `producer` | `capabilities.name` of the backend that computed the set, e.g. `"jsfeatnext"` |
+| `params` | Free-form, family-specific parameters, e.g. `{ "wtaK": 2 }` for ORB, `{ "scaleFactor": 1.0 }` for TEBLID. MAY be empty |
+| `count` | Rows `M` |
+| `levelStart` | `u32` accessor, `L + 1` entries: row ranges per level |
+| `kpIndex` | `u32` accessor, `M` entries: the keypoint each row describes |
+| `data` | Accessor with `type` `"u8"` for `"bits"` and `"u8"`, `"f32"` for `"f32"`; `count` = `M × bytesPerDescriptor` for `"u8"`, `M × dimensions` for `"f32"` |
+
+**Several sets, and what they are for.** A file MAY contain several sets. For example, `orb` and `teblid` let one file serve backends with different capabilities (§6.3). Two `orb` sets from different producers work around the "same kind, different bits" problem (ADR-0001, contract gaps). Uniqueness is on the key (`kind`, `norm`, `dimensions`, `producer`): two sets with the same key are `INCONSISTENT_DATA`.
+
+**Unknown families don't break the file.** A set whose `kind`, `norm` or `elementType` the reader does not know becomes unusable, with the warning `UNSUPPORTED_DESCRIPTOR_SET`. The rest of the file stays readable. Only a *structurally* broken set (an accessor out of bounds, `levelStart` inconsistent) makes the whole file invalid.
+
+**Rows are grouped by level**, in the same order as the keypoints. Per-level matching can therefore view one level without copying:
+
+```ts
+const bpd = set.bytesPerDescriptor;
+const a = set.levelStart[l], b = set.levelStart[l + 1];
+const levelSet: Descriptors = {
+    data: set.data.subarray(a * bpd, b * bpd),   // a view, not a copy
+    count: b - a, bytesPerDescriptor: bpd, kind: set.kind, norm: set.norm,
+};
+// after match(query, levelSet, …): keypoint index = set.kpIndex[a + m.trainIdx]
+```
+
+**Multi-view descriptors.** `kpIndex` lets several rows describe the same keypoint, e.g. descriptors computed on synthetic views (milestone M4). Multi-view rows break Lowe's ratio test, for the same reason pooled levels do (hence `matchPerLevel`): the two nearest rows can both be correct. A correct test requires the second-best row to belong to a *different* keypoint, which needs k-nearest matching that the contract does not expose yet.
+
+A reader that ignored `kpIndex` would therefore silently produce a worse ratio test. For that reason, `M ≠ N` or any repeated `kpIndex` value is allowed **only** when the extension `WKNF_multiview` is listed in `extensionsRequired`. Without it, writers MUST emit exactly one row per keypoint (`M = N`, `kpIndex[i] = i`).
+
+### 5.7 `patches` (optional)
+
+| Field | Accessor type, count | Content |
+|---|---|---|
+| `patchSize` | — | `P`, e.g. 8 |
+| `count` | — | `Q` |
+| `score` | `f32`, `Q` | Shi–Tomasi minimum eigenvalue |
+| `left`, `top` | `u16`, `Q` | Top-left pixel **in level coordinates** |
+| `level` | `u8`, `Q` | |
+| `pixels` | `u8`, `Q × P × P` | Row-major, `P × P` per patch |
+
+Patch `q` contains exactly `level_image[level[q]][top[q] + i][left[q] + j]` for `i, j ∈ [0, P)`. Integer placement makes the stored pixels unambiguous.
+
+Pixels are stored **without extra smoothing**: any blur is a tracker runtime parameter, not baked into the file. A file without `patches` is valid; the tracker then runs in detection-only mode (milestone M1).
+
+### 5.8 `referenceImage` (optional)
+
+```json
+{ "level": 0, "width": 1024, "height": 768, "pixels": 10 }
+```
+
+`pixels` is a `u8` accessor of `width × height` grayscale values, row-major. `width` and `height` MUST equal `pyramid.levelSizes[level]`. The image is optional because of its size (a full-resolution 1024 × 768 target adds 768 KiB). It enables re-compilation, debugging and dense refinement, and possibly re-description on the runtime backend (open question Q4).
+
+### 5.9 `info` (optional)
+
+Free-form. Readers MUST NOT require any field. Suggested content:
+
+```json
+{
+  "name": "pinball",
+  "createdAt": "2026-09-10T12:00:00Z",
+  "compiler": { "levels": 8, "maxKeypointsPerLevel": 260, "seed": 42 },
+  "trackability": 0.82
+}
+```
+
+## 6. Reader rules
+
+### 6.1 Validation order
+
+`.wnft` files may come from URLs chosen by an application's users, so the reader is exposed to untrusted input. It validates **in this order** and never allocates in proportion to a size before that size has been checked:
+
+1. **Container.** Buffer ≥ 16 bytes; `magic`; `container_major` supported; `total_length` equals the buffer length; every chunk header and its padded data within bounds; `JSON` first and unique; `BIN\0` at most once and in second place.
+2. **Checksums** of the `JSON` and `BIN\0` chunks.
+3. **Manifest size.** `chunk_length` of `JSON` ≤ the manifest limit (§6.4) *before* decoding.
+4. **Manifest decoding.** Strict UTF-8 (`new TextDecoder("utf-8", { fatal: true })`), then `JSON.parse` inside `try`/`catch`. Any failure — including a `RangeError` from pathological nesting — is `BAD_MANIFEST`. The top level MUST be an object.
+5. **Format version and required extensions** (§7).
+6. **Schema.** Required keys present with the right types; every accessor valid (§5.2) with the expected type and count; every count within the resource limits (§6.4).
+7. **Data consistency.** `levelStart` monotonic and closed; `level` agreeing with `levelStart`; `kpIndex[i] < N`; `meta` equal to `levelSizes[0]`; `bytesPerDescriptor` consistent with `elementType` and `dimensions`; the multi-view rule (§5.6).
+
+**Checked arithmetic.** Every product such as `count × size` is computed without overflow before it is compared with a length. In JS, products of two `u32` values are exact in `Number` (below `2^53`). In Rust, use `checked_mul` / `checked_add`, since a wrapped `u32` would pass the bounds check.
+
+### 6.2 Error and warning codes
+
+Readers return a result, never an exception, as ADR-0001 point 7 requires. Codes are shared by all implementations:
+
+| Error | Condition |
+|---|---|
+| `BAD_MAGIC` | `magic` ≠ `"WKNF"` |
+| `UNSUPPORTED_CONTAINER` | `container_major` unknown |
+| `BAD_CONTAINER` | `total_length` mismatch, chunk out of bounds, `JSON` chunk missing or duplicated, `BIN\0` duplicated or out of place, non-zero reserved field |
+| `CHECKSUM_MISMATCH` | A chunk's CRC-32 does not match |
+| `MANIFEST_TOO_LARGE` | `JSON` chunk above the manifest limit |
+| `BAD_MANIFEST` | Not strict UTF-8, not JSON, not an object, required key missing, wrong type |
+| `UNSUPPORTED_FORMAT_VERSION` | `format.version` not supported (§7) |
+| `UNSUPPORTED_EXTENSION` | A name in `extensionsRequired` the reader does not implement |
+| `BAD_LAYOUT` | Accessor out of bounds, misaligned, overlapping, or with the wrong type or count |
+| `LIMIT_EXCEEDED` | A count or size above the resource limits (§6.4) |
+| `INCONSISTENT_DATA` | Any rule of step 7 violated; duplicate descriptor-set key |
+| `NO_USABLE_DESCRIPTORS` | No descriptor set usable by the backend (§6.3) |
+
+| Warning | Condition |
+|---|---|
+| `UNKNOWN_CHUNK_SKIPPED` | A chunk with an unknown type |
+| `UNSUPPORTED_DESCRIPTOR_SET` | A set with an unknown `kind`, `norm` or `elementType`, skipped |
+| `PRODUCER_MISMATCH` | The chosen set's `producer` ≠ the runtime backend's `capabilities.name` |
+
+Warnings MUST be part of the returned result, not only logged to the console, so an application can act on them. `PRODUCER_MISMATCH` stays a warning until cross-backend descriptor conformance is established (ADR-0001, contract gaps).
+
+### 6.3 Choosing a descriptor set
+
+The application's preference order is intersected with the backend's capabilities, following the pattern documented in the contract. No silent substitution:
+
+```ts
+const preferred: DescriptorKind[] = ["teblid", "freak", "orb"];
+const usable = file.descriptorSets.filter((s) => cv.capabilities.descriptors.includes(s.kind));
+const chosen = preferred.map((k) => usable.find((s) => s.kind === k)).find(Boolean);
+if (!chosen) return { ok: false, error: "NO_USABLE_DESCRIPTORS" };
+```
+
+**Keypoints and foreign backends.** Readers and trackers MUST NOT pass stored keypoints to a backend's `describe` unless that backend's pyramid scale step is known to equal `pyramid.scaleStep`. Otherwise `describe` silently computes descriptors at the wrong scale. The contract does not expose the step yet, so today this means: never re-describe stored keypoints on a different backend.
+
+### 6.4 Resource limits
+
+Readers MUST enforce configurable limits and report `LIMIT_EXCEEDED` (or `MANIFEST_TOO_LARGE`) when they are exceeded. Suggested defaults:
+
+| Limit | Default |
+|---|---|
+| File size | 64 MiB |
+| Manifest (`JSON` chunk) | 1 MiB |
+| Pyramid levels | 32 |
+| Keypoints per file | 1,000,000 |
+| Descriptor sets per file | 16 |
+| Patch size `P` | 64 |
+
+## 7. Versioning and evolution
+
+### 7.1 Three layers
+
+| Layer | Where | Governs | Reader rule |
+|---|---|---|---|
+| **Container** | `container_major.minor` in the binary header | Framing: header, chunks, padding, checksum | Unknown major → `UNSUPPORTED_CONTAINER`, before reading anything else. A newer minor is accepted: container minors only add things readers can skip, such as new chunk types |
+| **Format** | `format.version` in the manifest | Meaning of the manifest and the arrays | While the major is `0`: only exactly the supported `major.minor`. From `1.0`: same major, any minor |
+| **Extensions** | `extensionsUsed` / `extensionsRequired` | Optional features | Unknown and required → `UNSUPPORTED_EXTENSION`. Unknown and only used → ignored |
+
+The same model is used by glTF 2.0: the GLB container has its own version number, and the JSON carries `asset.version`.
+
+The "exact minor" rule for `0.x` exists because, during the draft, each minor may break the one before. Without it, a `0.1` reader would accept a `0.3` file and silently misread it.
+
+### 7.2 How to change the format
+
+| Change | How | Version effect |
+|---|---|---|
+| New descriptor family (FREAK, TEBLID, …) | A new `descriptorSets` entry with a new `kind` | **None.** Old readers skip the set with a warning |
+| New parameter of a family | A key in `params` | None |
+| New optional field or array | A new manifest key, plus an accessor if it is an array | Minor |
+| Feature that old readers must not ignore (e.g. multi-view) | An extension listed in `extensionsRequired` | None, or minor when it enters the core |
+| Changed meaning of an existing field | Forbidden within a major: use a new key or an extension | Major |
+| Change to the container | New container minor (additive) or major | Container |
+
+### 7.3 Canonical writer
+
+The same content always produces the same bytes from the same implementation:
+- Chunks in the order `JSON`, `BIN\0`; no other chunks.
+- Manifest keys in the order this specification lists them; no insignificant whitespace; `descriptorSets` sorted by `kind`, `norm`, `dimensions`, `producer`.
+- Accessors in the order their fields first appear in the manifest, each starting at a multiple of 8, with zero padding in between.
+- `extensionsUsed` and `extensionsRequired` sorted, omitted when empty.
+
+JSON serializers in different languages may format the same number differently (for example `0.000001` versus `1e-6`). For that reason cross-implementation conformance compares manifests **after parsing**, and requires byte identity only for the `BIN\0` chunk (§8.2, open question Q8).
+
+## 8. Conformance and testing
+
+### 8.1 Fixtures
+
+Fixtures live in a directory shared by `vitest` and `cargo test` (e.g. `fixtures/nft-target/0.1/`). They are produced by a committed, deterministic generator script and never edited by hand:
+
+- `valid/minimal.wnft` — a tiny synthetic target (e.g. 64×48, 2 levels, ~20 keypoints, one `orb` set, `patches`), with `valid/minimal.json` holding its decoded values (manifest plus arrays as JSON lists).
+- `valid/` — further valid files: several descriptor sets, `L = 1`, zero keypoints, no `patches`, unaligned-base variant (§3).
+- `invalid/` — at least one file per error code in §6.2, each paired with its expected code.
+- `warnings/` — files that decode successfully with an exact list of expected warnings: unknown chunk, unknown descriptor `kind` next to a valid set, unknown `norm`, unknown optional extension.
+
+### 8.2 Required tests (every implementation)
+
+1. `decode(valid/minimal.wnft)` equals `valid/minimal.json`.
+2. **Same-implementation round trip:** `encode(decode(f))` is byte-identical to `f` for every valid fixture.
+3. **Cross-implementation:** `BIN\0` chunks byte-identical; manifests equal after parsing.
+4. Every `invalid/` file yields exactly its expected error code; every `warnings/` file yields `ok` with exactly its expected warnings.
+5. CRC-32 test vector: `123456789` → `0xCBF43926`.
+
+### 8.3 Evolution tests
+
+- A file declaring format `0.2` is rejected by a `0.1` reader with `UNSUPPORTED_FORMAT_VERSION`.
+- Unknown keys at the top level, inside a descriptor set and inside `params` are ignored.
+- An unknown extension in `extensionsRequired` → `UNSUPPORTED_EXTENSION`; the same extension only in `extensionsUsed` → ignored.
+- A file with two descriptor sets, one of an unknown family: the other remains usable.
+- `M ≠ N` without `WKNF_multiview` in `extensionsRequired` → `INCONSISTENT_DATA`.
+- **Backward-compatibility corpus.** Every released format version freezes its fixtures under `fixtures/nft-target/<version>/`. From then on, every reader either decodes them correctly or rejects them with an explicit error — never misreads them.
+
+### 8.4 Robustness tests (untrusted input)
+
+- **Truncation:** every valid fixture, truncated at every byte offset, yields `ok: false` and never throws.
+- **Property-based fuzzing** (`fast-check` in TS; `cargo-fuzz` in Rust): random bit flips and random counts, offsets and lengths. The reader never throws, always terminates and never allocates beyond the limits.
+- **Size arithmetic:** counts chosen so that `count × size` overflows `u32` or exceeds the chunk → `BAD_LAYOUT` or `LIMIT_EXCEEDED`, with no allocation.
+- **Manifest attacks:** a manifest one byte above the limit → `MANIFEST_TOO_LARGE`; deeply nested JSON, invalid UTF-8 → `BAD_MANIFEST`.
+- **Property-based round trip:** a random valid `TargetDb`, encoded then decoded, equals the original.
+
+## 9. Size estimate
+
+For 1,000 keypoints over 8 levels, one 256-bit ORB set, 50 patches of 8×8, and no `referenceImage`:
+
+| Part | Bytes |
+|---|---|
+| File header + 2 chunk headers | 48 |
+| Manifest | ~1.5 KB |
+| Keypoint arrays (21 B per keypoint) | ~21 KB |
+| Descriptor set (32 B data + 4 B `kpIndex` per row) | ~36 KB |
+| Patches (73 B per patch) | ~3.7 KB |
+| **Total** | **≈ 63 KB** |
+
+## 10. Decisions
+
+Decisions D1–D5 below are accepted as part of this specification.
+
+- **D1 — Model-plane origin:** level-0 pixel `(0, 0)`, top-left, `+Y` down. Centring is an option of the tracker API, never stored in the file. *(was Q1)*
+- **D2 — Half-pixel convention:** `x0 = x_l / s_l` without correction, as OpenCV ORB and `cv-backend-jsfeatnext`. The resulting bias (~2 px at level 7 with the `∛2` step) is smaller than the localisation uncertainty of a keypoint at that level (~5 px in level-0 pixels). *(was Q2)*
+- **D3 — Integrity:** CRC-32 per chunk in the container (§4.2). *(was Q5)*
+- **D4 — Extension:** `.wnft`. *(was Q7)*
+- **D5 — Structure:** a binary container with a JSON manifest and a binary data chunk, following glTF's GLB (§2).
+
+## 11. Open questions
+
+- **Q3 — Multi-view descriptors.** The format side is settled (`WKNF_multiview`, §5.6). Adoption is blocked on k-nearest matching in the contract.
+- **Q4 — Producer mismatch strategy.** Warn only (v0.1), or store a full-resolution `referenceImage` and re-describe on the runtime backend when its scale step matches. The second avoids bit incompatibility but costs about 1 byte per pixel.
+- **Q6 — Multiple targets.** v0.1 stores one target per file; a container of targets or a manifest of files could come later.
+- **Q8 — Canonical JSON numbers across languages.** Defining a strict number grammar for the manifest would give byte identity of the whole file across implementations, not only of the `BIN\0` chunk. It is probably not worth the complexity; to be revisited if the cross-implementation tests turn out to need it.
+- **Q9 — Media type** for serving `.wnft` (e.g. a vendor type such as `application/vnd.webarkit.nft-target`).

--- a/docs/specs/nft-target-format.md
+++ b/docs/specs/nft-target-format.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted (format 0.1). The format version is `0.1`: while the major is `0`, every minor may break compatibility (§7).
 **Decided by:** [ADR-0001](../adr/0001-nft-tracker-ts-reference-above-cvbackend.md), point 6.
-**Implementations:** `packages/nft-tracker/src/target/format` (TypeScript, which also hosts the fixture generator) and `crates/wnft-format` (Rust). The two are peers: this specification is the source of truth, and two independent implementations exist to expose its ambiguities.
+**Implementations (both planned, neither exists yet):** `packages/nft-tracker/src/target/format` (TypeScript, which will also host the fixture generator) and, **only if** the Rust port of [ADR-0001](../adr/0001-nft-tracker-ts-reference-above-cvbackend.md) point 5 is triggered, `crates/wnft-format` (Rust). The TypeScript codec is the one required implementation. Where both exist they are peers: this specification is the source of truth, and a second independent implementation is what exposes its ambiguities.
 
 The key words MUST, MUST NOT, SHOULD and MAY are used as in RFC 2119.
 
@@ -50,7 +50,9 @@ const LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
 
 When a file is not at an 8-aligned address — for example, a `.wnft` stored inside a larger `ArrayBuffer`, or embedded with Rust `include_bytes!`, which only guarantees 1-byte alignment — views may be impossible. JS typed arrays require the byte offset to be a multiple of the element size. Readers MUST detect this and fall back to copying the affected arrays. They MUST NOT read misaligned data through a view.
 
-**Pixel coordinates.** Integer coordinates are pixel centres, so a FAST corner at column 10 has `x = 10`. All keypoint and patch positions are stored in **level-0 coordinates**, i.e. pixels of the full-resolution reference image.
+**Pixel coordinates.** Integer coordinates are pixel centres, so a FAST corner at column 10 has `x = 10`. All **keypoint** positions are stored in **level-0 coordinates**, i.e. pixels of the full-resolution reference image; the level a keypoint came from is recorded separately in `keypoints.level`.
+
+**Patch positions are the one exception.** `patches.left` and `patches.top` are integer coordinates of the patch's own level, not level-0 (§5.7), because the stored pixels are read from that level's image at exactly those indices; storing them in level-0 coordinates would reintroduce a rounding step and make the stored pixels ambiguous. Convert to level-0 with the mapping below, using `patches.level` as `l`.
 
 **Level-to-level-0 mapping.** A point found at `x_l` on level `l` is stored as
 
@@ -276,7 +278,7 @@ A reader that ignored `kpIndex` would therefore silently produce a worse ratio t
 | `level` | `u8`, `Q` | |
 | `pixels` | `u8`, `Q × P × P` | Row-major, `P × P` per patch |
 
-Patch `q` contains exactly `level_image[level[q]][top[q] + i][left[q] + j]` for `i, j ∈ [0, P)`. Integer placement makes the stored pixels unambiguous.
+Patch `q` contains exactly `level_image[level[q]][top[q] + i][left[q] + j]` for `i, j ∈ [0, P)`. Integer placement makes the stored pixels unambiguous. These are the only positions in the file that are **not** in level-0 coordinates (§3); readers converting a patch to the model plane MUST map through `level[q]` first.
 
 Pixels are stored **without extra smoothing**: any blur is a tracker runtime parameter, not baked into the file. A file without `patches` is valid; the tracker then runs in detection-only mode (milestone M1).
 

--- a/docs/specs/nft-target-format.md
+++ b/docs/specs/nft-target-format.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted (format 0.1). The format version is `0.1`: while the major is `0`, every minor may break compatibility (§7).
 **Decided by:** [ADR-0001](../adr/0001-nft-tracker-ts-reference-above-cvbackend.md), point 6.
-**Implementations (both planned, neither exists yet):** `packages/nft-tracker/src/target/format` (TypeScript, which will also host the fixture generator) and, **only if** the Rust port of [ADR-0001](../adr/0001-nft-tracker-ts-reference-above-cvbackend.md) point 5 is triggered, `crates/wnft-format` (Rust). The TypeScript codec is the one required implementation. Where both exist they are peers: this specification is the source of truth, and a second independent implementation is what exposes its ambiguities.
+**Implementations (both planned, neither exists yet):** `packages/nft-tracker/src/target/format` (TypeScript, which will also host the fixture generator) and `crates/wnft-format` (Rust, see [ADR-0001](../adr/0001-nft-tracker-ts-reference-above-cvbackend.md) point 6). The TypeScript codec is required by the tracker; the Rust codec exists to validate this specification and is not part of the tracker port of ADR-0001 point 5. The two are peers: this specification is the source of truth, and a second independent implementation is what exposes its ambiguities.
 
 The key words MUST, MUST NOT, SHOULD and MAY are used as in RFC 2119.
 
@@ -35,7 +35,7 @@ The format has two layers, following the GLB container of glTF 2.0:
 
 Two properties follow from this split:
 
-- **Adding something never shifts existing bytes.** A new field is a new manifest key; a new array is a new accessor. Old readers ignore both (§7).
+- **Adding something never shifts existing bytes.** A new field is a new manifest key; a new array is a new accessor. Old readers ignore both (§7) — but only from format `1.0` on. While the major is `0`, a reader accepts nothing but its own exact minor and rejects every other one (§7.1), so additive changes are not yet forward-compatible in practice.
 - **Versioning happens at two layers, and each version governs only its own layer** (§7). This is not duplication: a reader must be able to reject a container it cannot frame *before* it looks for the manifest, and it can only read the format version *after* framing.
 
 ## 3. Conventions
@@ -165,6 +165,8 @@ Every array lives in the `BIN` chunk and is described by an accessor. Manifest f
 | `type` | `"u8"`, `"u16"`, `"u32"` or `"f32"` |
 
 Accessor rules:
+- `offset` and `count` MUST each be a JSON number with no fractional part, in `[0, 2^32 − 1]`. `NaN`, `Infinity`, negative and fractional values are `BAD_MANIFEST`, rejected **before** any arithmetic uses them, so that the checked arithmetic of §6.1 always operates on `u32` operands.
+- Every manifest field that references an accessor MUST be an integer in `[0, accessors.length)`. Anything else — a fractional index, a negative one, one past the end, or a non-number — is `BAD_MANIFEST`.
 - `offset + count × size(type)` MUST be `≤` the `BIN` chunk length, computed with checked arithmetic (§6.1).
 - Accessors MUST NOT overlap. Each array owns its bytes.
 - Every field that references an accessor fixes the expected `type` and `count`. A mismatch is `BAD_LAYOUT`.
@@ -187,6 +189,8 @@ Accessor rules:
 - `scaleStep` is the size ratio between consecutive levels, e.g. `2^(1/3)`.
 - The number of levels `L` is `levelSizes.length`, at least 1.
 - `levelSizes` are authoritative. Implementations round differently — `cv-backend-jsfeatnext` uses `(w * s) | 0` — so sizes are recorded as produced, not recomputed.
+- Every width and height in `levelSizes` MUST be a JSON number with no fractional part, in `[1, 2^16 − 1]`, and `scaleStep` MUST be finite and `> 1`. A violation of either is `BAD_MANIFEST`: a zero or negative size, or a `scaleStep` of `1` or less, makes the level mapping of §3 meaningless or a division by zero.
+- `levelSizes` MUST be non-increasing: for every `l`, `levelSizes[l+1][0] ≤ levelSizes[l][0]` and `levelSizes[l+1][1] ≤ levelSizes[l][1]`. A violation is `INCONSISTENT_DATA`.
 
 `scaleStep` is what gives meaning to a keypoint's `level`. The contract carries the level but not the step (ADR-0001, contract gaps).
 
@@ -251,6 +255,8 @@ Each entry is one descriptor set:
 
 **Unknown families don't break the file.** A set whose `kind`, `norm` or `elementType` the reader does not know becomes unusable, with the warning `UNSUPPORTED_DESCRIPTOR_SET`. The rest of the file stays readable. Only a *structurally* broken set (an accessor out of bounds, `levelStart` inconsistent) makes the whole file invalid.
 
+**Level ranges MUST be closed and agree with the keypoints.** For every set: `levelStart[0] = 0`, `levelStart[L] = M`, `levelStart` is non-decreasing, and every `kpIndex[i]` with `i ∈ [levelStart[l], levelStart[l+1])` MUST reference a keypoint whose `level` is `l`. Without the last rule a row could be matched at one level and then mapped onto a keypoint from another, silently corrupting the per-level correspondences that the view below produces. Any violation is `INCONSISTENT_DATA`.
+
 **Rows are grouped by level**, in the same order as the keypoints. Per-level matching can therefore view one level without copying:
 
 ```ts
@@ -280,6 +286,8 @@ A reader that ignored `kpIndex` would therefore silently produce a worse ratio t
 
 Patch `q` contains exactly `level_image[level[q]][top[q] + i][left[q] + j]` for `i, j ∈ [0, P)`. Integer placement makes the stored pixels unambiguous. These are the only positions in the file that are **not** in level-0 coordinates (§3); readers converting a patch to the model plane MUST map through `level[q]` first.
 
+Every patch MUST be in bounds: `level[q] < L`, `left[q] + P ≤ levelSizes[level[q]][0]` and `top[q] + P ≤ levelSizes[level[q]][1]`. A violation is `INCONSISTENT_DATA`, checked before any pixel is read.
+
 Pixels are stored **without extra smoothing**: any blur is a tracker runtime parameter, not baked into the file. A file without `patches` is valid; the tracker then runs in detection-only mode (milestone M1).
 
 ### 5.8 `referenceImage` (optional)
@@ -288,7 +296,7 @@ Pixels are stored **without extra smoothing**: any blur is a tracker runtime par
 { "level": 0, "width": 1024, "height": 768, "pixels": 10 }
 ```
 
-`pixels` is a `u8` accessor of `width × height` grayscale values, row-major. `width` and `height` MUST equal `pyramid.levelSizes[level]`. The image is optional because of its size (a full-resolution 1024 × 768 target adds 768 KiB). It enables re-compilation, debugging and dense refinement, and possibly re-description on the runtime backend (open question Q4).
+`pixels` is a `u8` accessor of `width × height` grayscale values, row-major. `level` MUST be `< L`, checked **before** `levelSizes[level]` is indexed, and `width` and `height` MUST then equal `pyramid.levelSizes[level]`. A violation of either is `INCONSISTENT_DATA`. The image is optional because of its size (a full-resolution 1024 × 768 target adds 768 KiB). It enables re-compilation, debugging and dense refinement, and possibly re-description on the runtime backend (open question Q4).
 
 ### 5.9 `info` (optional)
 
@@ -314,8 +322,12 @@ Free-form. Readers MUST NOT require any field. Suggested content:
 3. **Manifest size.** `chunk_length` of `JSON` ≤ the manifest limit (§6.4) *before* decoding.
 4. **Manifest decoding.** Strict UTF-8 (`new TextDecoder("utf-8", { fatal: true })`), then `JSON.parse` inside `try`/`catch`. Any failure — including a `RangeError` from pathological nesting — is `BAD_MANIFEST`. The top level MUST be an object.
 5. **Format version and required extensions** (§7).
-6. **Schema.** Required keys present with the right types; every accessor valid (§5.2) with the expected type and count; every count within the resource limits (§6.4).
-7. **Data consistency.** `levelStart` monotonic and closed; `level` agreeing with `levelStart`; `kpIndex[i] < N`; `meta` equal to `levelSizes[0]`; `bytesPerDescriptor` consistent with `elementType` and `dimensions`; the multi-view rule (§5.6).
+6. **Schema.** Required keys present with the right types; every accessor valid (§5.2), including the `[0, 2^32 − 1]` integer domains of `offset` and `count` and every accessor reference being an integer index in `[0, accessors.length)`, with the expected type and count; the pyramid domains of §5.4 (every `levelSizes` entry an integer in `[1, 2^16 − 1]`, `scaleStep` finite and `> 1`); every count within the resource limits (§6.4). Type and domain violations at this step are `BAD_MANIFEST`, and they are checked before any value reaches the arithmetic below.
+7. **Data consistency.** `levelStart` monotonic and closed; `level` agreeing with `levelStart`; `kpIndex[i] < N`; `meta` equal to `levelSizes[0]`; `bytesPerDescriptor` consistent with `elementType` and `dimensions`; the multi-view rule (§5.6). Also:
+   - `levelSizes` non-increasing from level to level (§5.4).
+   - For every descriptor set, `levelStart[0] = 0`, `levelStart[L] = M`, and every `kpIndex` inside the range of level `l` referencing a keypoint whose `level` is `l` (§5.6).
+   - For every patch, `level[q] < L`, `left[q] + P ≤ levelSizes[level[q]][0]` and `top[q] + P ≤ levelSizes[level[q]][1]` (§5.7).
+   - `referenceImage.level < L`, checked before its `width` and `height` are compared with `levelSizes[level]` (§5.8).
 
 **Checked arithmetic.** Every product such as `count × size` is computed without overflow before it is compared with a length. In JS, products of two `u32` values are exact in `Number` (below `2^53`). In Rust, use `checked_mul` / `checked_add`, since a wrapped `u32` would pass the bounds check.
 
@@ -341,21 +353,49 @@ Readers return a result, never an exception, as ADR-0001 point 7 requires. Codes
 | Warning | Condition |
 |---|---|
 | `UNKNOWN_CHUNK_SKIPPED` | A chunk with an unknown type |
-| `UNSUPPORTED_DESCRIPTOR_SET` | A set with an unknown `kind`, `norm` or `elementType`, skipped |
+| `UNSUPPORTED_DESCRIPTOR_SET` | A set with an unknown `kind`, `norm` or `elementType`, or one the runtime backend cannot consume (§6.3), skipped |
 | `PRODUCER_MISMATCH` | The chosen set's `producer` ≠ the runtime backend's `capabilities.name` |
 
 Warnings MUST be part of the returned result, not only logged to the console, so an application can act on them. `PRODUCER_MISMATCH` stays a warning until cross-backend descriptor conformance is established (ADR-0001, contract gaps).
 
 ### 6.3 Choosing a descriptor set
 
-The application's preference order is intersected with the backend's capabilities, following the pattern documented in the contract. No silent substitution:
+The application's preference order is intersected with the backend's capabilities, following the pattern documented in the contract. No silent substitution.
+
+A matching `kind` is **not** sufficient. This file format can store `elementType` `"u8"` and `"f32"` sets and any `norm`, while the contract represents descriptors as a `Uint8Array` and every `DescriptorKind` it defines today is binary. A set is therefore usable only if all three hold:
+
+- `elementType` is `"bits"`,
+- `norm` is `"hamming"`, and
+- `kind` is listed in `capabilities.descriptors`.
 
 ```ts
 const preferred: DescriptorKind[] = ["teblid", "freak", "orb"];
-const usable = file.descriptorSets.filter((s) => cv.capabilities.descriptors.includes(s.kind));
+
+const usable = file.descriptorSets.filter(
+    (s) =>
+        s.elementType === "bits" &&           // Descriptors.data is a Uint8Array
+        s.norm === "hamming" &&               // every current DescriptorKind is binary
+        cv.capabilities.descriptors.includes(s.kind),
+);
 const chosen = preferred.map((k) => usable.find((s) => s.kind === k)).find(Boolean);
 if (!chosen) return { ok: false, error: "NO_USABLE_DESCRIPTORS" };
 ```
+
+**The width must match too.** Two backends can both declare the same `kind` and still produce descriptors of a different size, and `match` cannot compare rows of different widths. Before using a set, the tracker MUST describe a probe on the runtime backend and compare. The probe MUST request the set's own size through `DescribeOptions.bits` — for a `"bits"` set that is `dimensions` — so that a 512-bit set is not rejected merely because the backend's default for that family is 256:
+
+```ts
+const probe = cv.describe(probeImage, probeKeypoints, {
+    kind: chosen.kind,
+    bits: chosen.dimensions,        // ignored by fixed-size families
+});
+if (probe.bytesPerDescriptor !== chosen.bytesPerDescriptor || probe.norm !== chosen.norm) {
+    // unusable: warn UNSUPPORTED_DESCRIPTOR_SET and fall through to the next candidate
+}
+```
+
+The probe checks descriptor **shape**, not bit compatibility: two backends producing the same `kind` at the same size can still compute different bits, and only `PRODUCER_MISMATCH` covers that.
+
+A set failing any of these checks is unusable: the reader reports the warning `UNSUPPORTED_DESCRIPTOR_SET` and moves on to the next candidate. When no set survives, the result is the error `NO_USABLE_DESCRIPTORS`. This does not cover *bit* compatibility between two backends declaring the same `kind` — that gap is `PRODUCER_MISMATCH` and ADR-0001's contract gaps.
 
 **Keypoints and foreign backends.** Readers and trackers MUST NOT pass stored keypoints to a backend's `describe` unless that backend's pyramid scale step is known to equal `pyramid.scaleStep`. Otherwise `describe` silently computes descriptors at the wrong scale. The contract does not expose the step yet, so today this means: never re-describe stored keypoints on a different backend.
 
@@ -397,6 +437,8 @@ The "exact minor" rule for `0.x` exists because, during the draft, each minor ma
 | Changed meaning of an existing field | Forbidden within a major: use a new key or an extension | Major |
 | Change to the container | New container minor (additive) or major | Container |
 
+**While the major is `0`, every "Minor" row above means old readers reject the file**, not that they ignore the addition: §7.1 requires an exact minor match during `0.x`. The additive forward compatibility that §2 describes begins at `1.0`.
+
 ### 7.3 Canonical writer
 
 The same content always produces the same bytes from the same implementation:
@@ -415,7 +457,7 @@ Fixtures live in a directory shared by `vitest` and `cargo test` (e.g. `fixtures
 
 - `valid/minimal.wnft` — a tiny synthetic target (e.g. 64×48, 2 levels, ~20 keypoints, one `orb` set, `patches`), with `valid/minimal.json` holding its decoded values (manifest plus arrays as JSON lists).
 - `valid/` — further valid files: several descriptor sets, `L = 1`, zero keypoints, no `patches`, unaligned-base variant (§3).
-- `invalid/` — at least one file per error code in §6.2, each paired with its expected code.
+- `invalid/` — at least one file per error code in §6.2, each paired with its expected code, **plus one file per validation rule of §§5.2, 5.4, 5.6, 5.7 and 5.8**: a fractional `offset`; a negative `count`; a `count` above `2^32 − 1`; an accessor reference that is not an integer index below `accessors.length`; a level size of `0`; a level size above `2^16 − 1`; a `scaleStep` of `1`; `levelSizes` growing between two levels; a set with `levelStart[0] ≠ 0`; a set with `levelStart[L] ≠ M`; a `kpIndex` referencing a keypoint of another level; a patch whose `level[q] ≥ L`; a patch rectangle crossing the right or bottom edge of its level; a `referenceImage.level ≥ L`.
 - `warnings/` — files that decode successfully with an exact list of expected warnings: unknown chunk, unknown descriptor `kind` next to a valid set, unknown `norm`, unknown optional extension.
 
 ### 8.2 Required tests (every implementation)


### PR DESCRIPTION
## What

Adds the first two design records for the upcoming NFT tracker, both accepted:

- **`docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md`** — the NFT
  tracker is implemented in TypeScript in a new `packages/nft-tracker`, *above*
  the `CvBackend` contract, with the backend injected by the caller. A Rust port
  inside WebARKitLib-rs stays possible but is conditional on measured thresholds
  (JS↔WASM boundary overhead > 10% of the frame budget at p95, or tracker-side
  compute > 8 ms at p95), not scheduled. The ADR also lists the contract gaps it
  surfaced, to be filed as separate `cv-backend-spec` issues.
- **`docs/specs/nft-target-format.md`** — the `.wnft` trained-target format:
  a GLB-style binary container with a JSON manifest and a binary data chunk,
  accessors, reader validation order, error codes and conformance tests.
  Decisions D1–D5 are accepted; format version `0.1`.

The format, not the TS source, is the contract between implementations, which is
why it is specified before any code reads or writes it.

Action items 1 and 2 of the ADR are ticked by this PR; 3–7 remain open and
describe the work that follows.

## Also in this PR

- **`AGENTS.md` — new "Design records" section:** points at `docs/adr/` and
  `docs/specs/`, and states that an accepted ADR is never edited in place — it is
  superseded by a new ADR, with the old one marked `Superseded by ADR-XXXX`.
- **`AGENTS.md` — new "Language" rule:** every repository artifact (code,
  comments, commit messages, PR titles and bodies, issues, docs) is written in
  English, whatever language the conversation with the agent uses.
- **`.claude/agents/nft-reviewer.md`** — a read-only reviewer subagent that
  checks NFT-related diffs against ADR-0001, the target format spec and
  AGENTS.md (dependency arrow, portability rules, spec conformance, capability
  negotiation, tests, conventions).

## Verification

No source code changes; documentation and one agent definition only.

- `npm run build` — pass (spec, then jsfeatnext)
- `npm run typecheck` — pass
- `npm test` — pass (30 + 13 tests)
- Relative links between the ADR and the spec, and the new `AGENTS.md` links,
  all resolve.

Note: run under Node v24.20.0; `.nvmrc` pins v24.18.0, which is not installed on
this machine. CI runs the pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
