### PR TITLE
feat(nft-tracker): scaffold the package and the in-memory target types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ If you're deciding where to plug in: **jsfeatNext** is the place to start today 
 |---|---|
 | [`@webarkit/cv-backend-spec`](./packages/cv-backend-spec) | Minimal stateless CV backend interface (`detect`, `describe`, `match`, `estimateHomography`, `poseFromHomography`) implemented by jsfeatNext and (future) WebARKitLib-rs. |
 | [`@webarkit/cv-backend-jsfeatnext`](./packages/cv-backend-jsfeatnext) | The jsfeatNext implementation of that contract. Depends on the spec **and** on `@webarkit/jsfeat-next` (>= 0.16.0); neither of those depends on it. |
+| [`@webarkit/nft-tracker`](./packages/nft-tracker) | Natural-feature tracking for planar image targets, written **above** the contract. Depends on the spec alone — the backend is injected by the caller, so it runs on any implementation. Currently the in-memory target types only; see [ADR-0001](./docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md) and the [target format spec](./docs/specs/nft-target-format.md). |
 
-Neither package is published to npm yet — see [Getting started](#-getting-started) for installing from source.
+None of the three is published to npm yet — see [Getting started](#-getting-started) for installing from source. `nft-tracker` is `private` and pre-0.1.
 
 ## 🚀 Getting started
 
@@ -54,12 +55,12 @@ cd webarkit
 npm install
 ```
 
-`npm install` resolves and symlinks both workspace packages, so `cv-backend-jsfeatnext` picks up `cv-backend-spec` straight from the sibling folder — no publish step needed to develop against both together.
+`npm install` resolves and symlinks every workspace package, so `cv-backend-jsfeatnext` and `nft-tracker` pick up `cv-backend-spec` straight from the sibling folder — no publish step needed to develop against them together.
 
 ### Build, typecheck, test
 
 ```bash
-npm run build       # builds cv-backend-spec, then cv-backend-jsfeatnext (in that order — see .github/workflows/CI.yml)
+npm run build       # cv-backend-spec, then cv-backend-jsfeatnext, then nft-tracker (in that order — see .github/workflows/CI.yml)
 npm run typecheck   # tsc across src/ + test/ in every workspace
 npm test            # vitest across every workspace
 ```
@@ -82,8 +83,10 @@ See [`examples/README.md`](./examples/README.md) for what each demo shows, why t
 ## 🗂️ Layout
 
 This is an npm-workspaces monorepo — no build-system layer ([Turborepo](https://turbo.build/repo/docs)/[Nx](https://nx.dev))
-yet; adding one is premature at two packages. Revisit once there are
-several, or once builds start depending on each other's outputs.
+yet; at three packages, ordering the build steps by hand is still simpler
+than standing up a task graph. Revisit once there are several more, or once
+builds start depending on each other's outputs in a way plain scripts
+cannot express.
 
 ```
 webarkit/
@@ -91,6 +94,7 @@ webarkit/
   packages/
     cv-backend-spec/
     cv-backend-jsfeatnext/
+    nft-tracker/
 ```
 
 ## ❓ Open questions for discussion

--- a/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
+++ b/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md
@@ -135,7 +135,7 @@ The expected cost of Option A on a WASM backend is small but unmeasured: trackin
 
 1. [x] Review and accept this ADR; add a pointer to `docs/adr/` in `AGENTS.md`.
 2. [x] Review and accept [`docs/specs/nft-target-format.md`](../specs/nft-target-format.md) (v0).
-3. [ ] Scaffold `packages/nft-tracker` (package.json, tsconfig, vitest, LGPL headers) and append it to the root `build` script **after** the spec — the build order is load-bearing.
+3. [x] Scaffold `packages/nft-tracker` (package.json, tsconfig, vitest, LGPL headers) and append it to the root `build` script **after** the spec — the build order is load-bearing.
 4. [ ] **M1 — parity:** a detection-only `NftTracker` equivalent to the webcam demo; move `buildLevelIndex` / `matchPerLevel` from `examples/js/pinball-shared.mjs` into the package, with tests.
 5. [ ] File the contract issues listed under "Contract gaps".
 6. [ ] Pick the reference device; record baseline numbers for the stateless demo.

--- a/docs/specs/nft-target-format.md
+++ b/docs/specs/nft-target-format.md
@@ -207,7 +207,7 @@ Accessor rules:
 | Field | Accessor type, count | Content |
 |---|---|---|
 | `count` | — | `N` |
-| `detector` | — | `kind` (a `DetectorKind` string) and free-form `params`. Informative, except where a descriptor's parameters depend on the detector (§5.6) |
+| `detector` | — | `kind` (a `DetectorKind` string) and free-form `params`, which is optional — an absent `params` is equivalent to `{}` (§7.3). Informative, except where a descriptor's parameters depend on the detector (§5.6) |
 | `levelStart` | `u32`, `L + 1` | Keypoints of level `l` are the indices `[levelStart[l], levelStart[l+1])`; `levelStart[L] = N` |
 | `x`, `y` | `f32`, `N` | Level-0 coordinates (§3) |
 | `angle` | `f32`, `N` | Radians |
@@ -245,11 +245,13 @@ Each entry is one descriptor set:
 | `dimensions` | Number of bits for `"bits"`, number of elements otherwise |
 | `bytesPerDescriptor` | MUST equal `dimensions / 8` for `"bits"` (`dimensions` a multiple of 8), `dimensions` for `"u8"`, `4 × dimensions` for `"f32"` |
 | `producer` | `capabilities.name` of the backend that computed the set, e.g. `"jsfeatnext"` |
-| `params` | Free-form, family-specific parameters, e.g. `{ "wtaK": 2 }` for ORB, `{ "scaleFactor": 1.0 }` for TEBLID. MAY be empty |
+| `params` | Free-form, family-specific parameters, e.g. `{ "wtaK": 2 }` for ORB, `{ "scaleFactor": 1.0 }` for TEBLID. Optional: an absent `params` is equivalent to `{}`, and the canonical writer omits it when empty (§7.3) |
 | `count` | Rows `M` |
 | `levelStart` | `u32` accessor, `L + 1` entries: row ranges per level |
 | `kpIndex` | `u32` accessor, `M` entries: the keypoint each row describes |
 | `data` | Accessor with `type` `"u8"` for `"bits"` and `"u8"`, `"f32"` for `"f32"`; `count` = `M × bytesPerDescriptor` for `"u8"`, `M × dimensions` for `"f32"` |
+
+**`params` is data, not unknown keys.** The same holds for `info` (§5.9). Their contents are free-form *by design*, so a reader preserves them as-is and round-trips them unchanged — which is exactly what §7.3 does not promise for unrecognised keys elsewhere. These two objects are specified to carry arbitrary content, so carrying it *is* understanding it.
 
 **Several sets, and what they are for.** A file MAY contain several sets. For example, `orb` and `teblid` let one file serve backends with different capabilities (§6.3). Two `orb` sets from different producers work around the "same kind, different bits" problem (ADR-0001, contract gaps). Uniqueness is on the key (`kind`, `norm`, `dimensions`, `producer`): two sets with the same key are `INCONSISTENT_DATA`.
 
@@ -447,6 +449,10 @@ The same content always produces the same bytes from the same implementation:
 - Accessors in the order their fields first appear in the manifest, each starting at a multiple of 8, with zero padding in between.
 - `extensionsUsed` and `extensionsRequired` sorted, omitted when empty.
 
+**A decoder keeps only what it understands, and the canonical writer emits only that.** Unknown keys, and unknown non-required extensions with their payloads, are ignored on decode and not preserved on encode: an implementation cannot keep data it does not understand consistent, for example when accessors are renumbered.
+
+**Optional objects and arrays that are empty** (`params`, `extensionsUsed`, `extensionsRequired`) are omitted by the canonical writer; readers treat an absent one as empty.
+
 JSON serializers in different languages may format the same number differently (for example `0.000001` versus `1e-6`). For that reason cross-implementation conformance compares manifests **after parsing**, and requires byte identity only for the `BIN\0` chunk (§8.2, open question Q8).
 
 ## 8. Conformance and testing
@@ -459,14 +465,16 @@ Fixtures live in a directory shared by `vitest` and `cargo test` (e.g. `fixtures
 - `valid/` — further valid files: several descriptor sets, `L = 1`, zero keypoints, no `patches`, unaligned-base variant (§3).
 - `invalid/` — at least one file per error code in §6.2, each paired with its expected code, **plus one file per validation rule of §§5.2, 5.4, 5.6, 5.7 and 5.8**: a fractional `offset`; a negative `count`; a `count` above `2^32 − 1`; an accessor reference that is not an integer index below `accessors.length`; a level size of `0`; a level size above `2^16 − 1`; a `scaleStep` of `1`; `levelSizes` growing between two levels; a set with `levelStart[0] ≠ 0`; a set with `levelStart[L] ≠ M`; a `kpIndex` referencing a keypoint of another level; a patch whose `level[q] ≥ L`; a patch rectangle crossing the right or bottom edge of its level; a `referenceImage.level ≥ L`.
 - `warnings/` — files that decode successfully with an exact list of expected warnings: unknown chunk, unknown descriptor `kind` next to a valid set, unknown `norm`, unknown optional extension.
+- `noncanonical/` — valid files that are **not** what the canonical writer (§7.3) would produce, each paired with the `valid/` file it is equivalent to: different manifest key order; insignificant whitespace; an explicit empty `params`; an unknown top-level key; an unknown non-required extension payload on a descriptor set.
 
 ### 8.2 Required tests (every implementation)
 
 1. `decode(valid/minimal.wnft)` equals `valid/minimal.json`.
-2. **Same-implementation round trip:** `encode(decode(f))` is byte-identical to `f` for every valid fixture.
-3. **Cross-implementation:** `BIN\0` chunks byte-identical; manifests equal after parsing.
-4. Every `invalid/` file yields exactly its expected error code; every `warnings/` file yields `ok` with exactly its expected warnings.
-5. CRC-32 test vector: `123456789` → `0xCBF43926`.
+2. **Same-implementation round trip:** `encode(decode(f))` is byte-identical to `f` for every `valid/` fixture. The guarantee is scoped to **canonical files whose content the implementation fully understands**, which every `valid/` fixture is by construction — §7.3 discards unknown content, so no implementation can promise byte identity for a file carrying some.
+3. **Non-canonical inputs:** every `noncanonical/` fixture decodes to the same values as its `valid/` counterpart, and `encode(decode(f))` equals **that counterpart** byte for byte — not the input. This is what makes §7.3's "keeps only what it understands" testable rather than a disclaimer.
+4. **Cross-implementation:** `BIN\0` chunks byte-identical; manifests equal after parsing.
+5. Every `invalid/` file yields exactly its expected error code; every `warnings/` file yields `ok` with exactly its expected warnings.
+6. CRC-32 test vector: `123456789` → `0xCBF43926`.
 
 ### 8.3 Evolution tests
 
@@ -515,3 +523,8 @@ Decisions D1–D5 below are accepted as part of this specification.
 - **Q6 — Multiple targets.** v0.1 stores one target per file; a container of targets or a manifest of files could come later.
 - **Q8 — Canonical JSON numbers across languages.** Defining a strict number grammar for the manifest would give byte identity of the whole file across implementations, not only of the `BIN\0` chunk. It is probably not worth the complexity; to be revisited if the cross-implementation tests turn out to need it.
 - **Q9 — Media type** for serving `.wnft` (e.g. a vendor type such as `application/vnd.webarkit.nft-target`).
+
+## 12. Revision history
+
+- **0.1 rev 1** — accepted text ([#20](https://github.com/webarkit/webarkit/pull/20)).
+- **0.1 rev 2** (2026-09-11) — editorial: round-trip scope, canonical omission of empty optionals, unknown content not preserved. No change to the bytes or the meaning of any valid `0.1` file.

--- a/docs/specs/nft-target-format.md
+++ b/docs/specs/nft-target-format.md
@@ -146,7 +146,9 @@ The `JSON` chunk holds one JSON object: UTF-8, no BOM.
 | `info` | no | §5.9 |
 | `accessors` | yes | §5.2 |
 
-**Unknown keys.** Readers MUST ignore keys they do not know, at every level. Writers MUST NOT use a new key to change the meaning of existing data (§7).
+**Unknown keys.** Readers MUST ignore keys they do not know, at every level, and MUST NOT re-emit them (§7.3). Writers MUST NOT use a new key to change the meaning of existing data (§7).
+
+**The exception is `params` and `info`.** Those two objects are specified to carry arbitrary content (§5.5, §5.6, §5.9), so their keys are never "unknown": a reader preserves them as-is and round-trips them unchanged. The rule above applies to keys *beside* them, not to keys *inside* them.
 
 **Extensions.** An extension has a name with the `WKNF_` prefix (e.g. `WKNF_multiview`) and may attach data to any object under an `"extensions": { "WKNF_name": { … } }` key, as in glTF.
 
@@ -256,6 +258,11 @@ Each entry is one descriptor set:
 **Several sets, and what they are for.** A file MAY contain several sets. For example, `orb` and `teblid` let one file serve backends with different capabilities (§6.3). Two `orb` sets from different producers work around the "same kind, different bits" problem (ADR-0001, contract gaps). Uniqueness is on the key (`kind`, `norm`, `dimensions`, `producer`): two sets with the same key are `INCONSISTENT_DATA`.
 
 **Unknown families don't break the file.** A set whose `kind`, `norm` or `elementType` the reader does not know becomes unusable, with the warning `UNSUPPORTED_DESCRIPTOR_SET`. The rest of the file stays readable. Only a *structurally* broken set (an accessor out of bounds, `levelStart` inconsistent) makes the whole file invalid.
+
+Unusable does not mean handled identically, because `elementType` is what says how to read the bytes:
+
+- **Unknown `kind` or `norm`, known `elementType`.** The set is structurally understood — the reader knows the element width, the row count and which keypoint each row describes — so it is **preserved** and re-emitted unchanged. It stays unusable and still warns.
+- **Unknown `elementType`.** Nothing says how wide an element is or which accessor type to expect, so the set cannot be interpreted at all. It is **dropped on decode**, with the same warning, and does not reappear on encode — §7.3's rule, applied to a descriptor set.
 
 **Level ranges MUST be closed and agree with the keypoints.** For every set: `levelStart[0] = 0`, `levelStart[L] = M`, `levelStart` is non-decreasing, and every `kpIndex[i]` with `i ∈ [levelStart[l], levelStart[l+1])` MUST reference a keypoint whose `level` is `l`. Without the last rule a row could be matched at one level and then mapped onto a keypoint from another, silently corrupting the per-level correspondences that the view below produces. Any violation is `INCONSISTENT_DATA`.
 
@@ -448,8 +455,13 @@ The same content always produces the same bytes from the same implementation:
 - Manifest keys in the order this specification lists them; no insignificant whitespace; `descriptorSets` sorted by `kind`, `norm`, `dimensions`, `producer`.
 - Accessors in the order their fields first appear in the manifest, each starting at a multiple of 8, with zero padding in between.
 - `extensionsUsed` and `extensionsRequired` sorted, omitted when empty.
+- Inside `params` and `info`, object keys sorted by **Unicode code point**, recursively. Their content is arbitrary, so it has no specified key order of its own; sorting is what makes the round trip byte-identical.
+
+  > **TypeScript implementers.** `JSON.stringify` does not produce this order. JavaScript objects enumerate integer-like keys numerically and first, so `{"10":a,"9":b}` serializes as `"9"` before `"10"`, whereas code-point order puts `"10"` first. These two objects MUST therefore be serialized explicitly, not handed to `JSON.stringify`.
 
 **A decoder keeps only what it understands, and the canonical writer emits only that.** Unknown keys, and unknown non-required extensions with their payloads, are ignored on decode and not preserved on encode: an implementation cannot keep data it does not understand consistent, for example when accessors are renumbered.
+
+When an unknown non-required extension is ignored, **its name is also removed from `extensionsUsed`**. The decoded `extensionsUsed` therefore lists only extensions the implementation understands, and re-encoding does not advertise a payload that is no longer there. (`extensionsRequired` needs no such rule: an unknown name there is `UNSUPPORTED_EXTENSION` and the file never decodes at all, §6.1 step 5.)
 
 **Optional objects and arrays that are empty** (`params`, `extensionsUsed`, `extensionsRequired`) are omitted by the canonical writer; readers treat an absent one as empty.
 
@@ -465,7 +477,7 @@ Fixtures live in a directory shared by `vitest` and `cargo test` (e.g. `fixtures
 - `valid/` — further valid files: several descriptor sets, `L = 1`, zero keypoints, no `patches`, unaligned-base variant (§3).
 - `invalid/` — at least one file per error code in §6.2, each paired with its expected code, **plus one file per validation rule of §§5.2, 5.4, 5.6, 5.7 and 5.8**: a fractional `offset`; a negative `count`; a `count` above `2^32 − 1`; an accessor reference that is not an integer index below `accessors.length`; a level size of `0`; a level size above `2^16 − 1`; a `scaleStep` of `1`; `levelSizes` growing between two levels; a set with `levelStart[0] ≠ 0`; a set with `levelStart[L] ≠ M`; a `kpIndex` referencing a keypoint of another level; a patch whose `level[q] ≥ L`; a patch rectangle crossing the right or bottom edge of its level; a `referenceImage.level ≥ L`.
 - `warnings/` — files that decode successfully with an exact list of expected warnings: unknown chunk, unknown descriptor `kind` next to a valid set, unknown `norm`, unknown optional extension.
-- `noncanonical/` — valid files that are **not** what the canonical writer (§7.3) would produce, each paired with the `valid/` file it is equivalent to: different manifest key order; insignificant whitespace; an explicit empty `params`; an unknown top-level key; an unknown non-required extension payload on a descriptor set.
+- `noncanonical/` — valid files that are **not** what the canonical writer (§7.3) would produce, each paired with the `valid/` file it is equivalent to: different manifest key order; insignificant whitespace; an explicit empty `params`; an unknown top-level key; an unknown non-required extension payload on a descriptor set; **`params` whose keys are unsorted and include `"9"` and `"10"`**, which catches an implementation that serialized them with `JSON.stringify`.
 
 ### 8.2 Required tests (every implementation)
 
@@ -479,7 +491,8 @@ Fixtures live in a directory shared by `vitest` and `cargo test` (e.g. `fixtures
 ### 8.3 Evolution tests
 
 - A file declaring format `0.2` is rejected by a `0.1` reader with `UNSUPPORTED_FORMAT_VERSION`.
-- Unknown keys at the top level, inside a descriptor set and inside `params` are ignored.
+- Unknown keys at the top level and inside a descriptor set are ignored and are not re-emitted.
+- Keys inside `params` and inside `info` are **data**: they are preserved and re-emitted unchanged, whatever they are (§5.1).
 - An unknown extension in `extensionsRequired` → `UNSUPPORTED_EXTENSION`; the same extension only in `extensionsUsed` → ignored.
 - A file with two descriptor sets, one of an unknown family: the other remains usable.
 - `M ≠ N` without `WKNF_multiview` in `extensionsRequired` → `INCONSISTENT_DATA`.
@@ -523,8 +536,9 @@ Decisions D1–D5 below are accepted as part of this specification.
 - **Q6 — Multiple targets.** v0.1 stores one target per file; a container of targets or a manifest of files could come later.
 - **Q8 — Canonical JSON numbers across languages.** Defining a strict number grammar for the manifest would give byte identity of the whole file across implementations, not only of the `BIN\0` chunk. It is probably not worth the complexity; to be revisited if the cross-implementation tests turn out to need it.
 - **Q9 — Media type** for serving `.wnft` (e.g. a vendor type such as `application/vnd.webarkit.nft-target`).
+- **Q10 — I-JSON.** Require the manifest to be I-JSON ([RFC 7493](https://www.rfc-editor.org/rfc/rfc7493)): no duplicate keys, numbers representable as IEEE 754 doubles. Without it, two conforming decoders can read the same untrusted file differently (`JSON.parse` keeps the last duplicate). To decide before the TS codec is written.
 
 ## 12. Revision history
 
 - **0.1 rev 1** — accepted text ([#20](https://github.com/webarkit/webarkit/pull/20)).
-- **0.1 rev 2** (2026-09-11) — editorial: round-trip scope, canonical omission of empty optionals, unknown content not preserved. No change to the bytes or the meaning of any valid `0.1` file.
+- **0.1 rev 2** (2026-09-11) — editorial: round-trip scope, canonical omission of empty optionals, unknown content not preserved, `params`/`info` content preserved as data, `extensionsUsed` pruned to what the reader understands, key ordering inside `params`/`info`, and the split between a preserved unknown `kind`/`norm` and a dropped unknown `elementType`. No change to the bytes or the meaning of any valid `0.1` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -469,6 +469,10 @@
       "integrity": "sha512-O9R0C+Z56aHRDS4Ox8J8jJ12R2DwRZqFjrVt/NvVSAM46xtBezwQNnI4W1nzxo9n5J5hBoUqiTcPKBVKqDXTOQ==",
       "license": "LGPL-3.0-or-later"
     },
+    "node_modules/@webarkit/nft-tracker": {
+      "resolved": "packages/nft-tracker",
+      "link": true
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1264,6 +1268,19 @@
       "version": "0.1.0",
       "license": "LGPL-3.0-or-later",
       "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.11"
+      }
+    },
+    "packages/nft-tracker": {
+      "name": "@webarkit/nft-tracker",
+      "version": "0.0.0",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@webarkit/cv-backend-spec": "0.1.0"
+      },
+      "devDependencies": {
+        "@webarkit/cv-backend-jsfeatnext": "0.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.11"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w @webarkit/cv-backend-spec && npm run build -w @webarkit/cv-backend-jsfeatnext",
+    "build": "npm run build -w @webarkit/cv-backend-spec && npm run build -w @webarkit/cv-backend-jsfeatnext && npm run build -w @webarkit/nft-tracker",
     "prepare": "npm run build",
     "test": "npm run test --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",

--- a/packages/nft-tracker/package.json
+++ b/packages/nft-tracker/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@webarkit/nft-tracker",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Natural-feature tracking for planar image targets, written above the @webarkit/cv-backend-spec CvBackend contract.",
+  "license": "LGPL-3.0-or-later",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "webarkit",
+    "webar",
+    "nft",
+    "tracking",
+    "computer-vision"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webarkit/webarkit.git",
+    "directory": "packages/nft-tracker"
+  },
+  "dependencies": {
+    "@webarkit/cv-backend-spec": "0.1.0"
+  },
+  "devDependencies": {
+    "@webarkit/cv-backend-jsfeatnext": "0.1.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.11"
+  }
+}

--- a/packages/nft-tracker/src/index.ts
+++ b/packages/nft-tracker/src/index.ts
@@ -1,0 +1,54 @@
+/*
+ *  index.ts
+ *  nft-tracker
+ *
+ *  This file is part of nft-tracker - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  nft-tracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  nft-tracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with nft-tracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *             Thorsten Bux @ThorstenBux https://github.com/ThorstenBux
+ *
+ */
+
+export type {
+    BitsDescriptorSet,
+    DescriptorSet,
+    DetectorInfo,
+    F32DescriptorSet,
+    KeypointTable,
+    Params,
+    PatchTable,
+    PyramidInfo,
+    ReferenceImage,
+    TargetDb,
+    TargetInfo,
+    TargetMeta,
+    U8DescriptorSet,
+} from "./target/types.js";

--- a/packages/nft-tracker/src/index.ts
+++ b/packages/nft-tracker/src/index.ts
@@ -42,6 +42,7 @@ export type {
     DescriptorSet,
     DetectorInfo,
     F32DescriptorSet,
+    JsonValue,
     KeypointTable,
     Params,
     PatchTable,

--- a/packages/nft-tracker/src/target/types.ts
+++ b/packages/nft-tracker/src/target/types.ts
@@ -1,0 +1,331 @@
+/*
+ *  types.ts
+ *  nft-tracker
+ *
+ *  This file is part of nft-tracker - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  nft-tracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  nft-tracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with nft-tracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *             Thorsten Bux @ThorstenBux https://github.com/ThorstenBux
+ *
+ */
+
+/**
+ * The **in-memory** shape of a trained NFT target.
+ *
+ * This is the decoded form of a `.wnft` file, as specified in
+ * `docs/specs/nft-target-format.md` (format 0.1). Section references below
+ * point into that document, which is the source of truth: where these types
+ * and the specification disagree, the specification wins.
+ *
+ * Two flows meet here, which is why the shape is defined before either is
+ * written: the **target compiler** produces a `TargetDb`, and the **codec**
+ * decodes one from bytes and encodes one back.
+ *
+ * **What is deliberately absent.** Accessors, chunks, byte offsets, padding
+ * and CRC-32 are framing concerns of the codec (§4, §5.2). Nothing here
+ * describes where a value sat in the file — only what it means once read.
+ * A consumer of a `TargetDb` never needs to know it came from a file at all.
+ *
+ * @see {@link https://github.com/webarkit/webarkit/blob/dev/docs/specs/nft-target-format.md}
+ */
+
+import type {
+    DescriptorKind,
+    DescriptorNorm,
+    DetectorKind,
+} from "@webarkit/cv-backend-spec";
+
+/**
+ * A value the contract enumerates, or any other string the file may carry.
+ *
+ * The contract's `DescriptorKind`, `DescriptorNorm` and `DetectorKind` are
+ * closed unions of what backends implement *today*. A `.wnft` file is not
+ * bound by that: §5.6 requires a set whose family or metric the reader does
+ * not know to stay **present but unusable** (warning
+ * `UNSUPPORTED_DESCRIPTOR_SET`) while the rest of the file keeps working. A
+ * closed union could not represent such a set at all, so the codec would have
+ * to drop it and contradict the specification.
+ *
+ * The `(string & {})` half keeps editor completion for the known values while
+ * still accepting the unknown ones.
+ */
+type Known<T extends string> = T | (string & {});
+
+/** Free-form, implementation-defined parameters (§5.5, §5.6, §5.9). */
+export type Params = Readonly<Record<string, unknown>>;
+
+/**
+ * Physical and pixel size of the target (§5.3).
+ *
+ * `widthPx`/`heightPx` equal `pyramid.levelSizes[0]`; the codec enforces that,
+ * these types only record it.
+ */
+export interface TargetMeta {
+    readonly widthPx: number;
+    readonly heightPx: number;
+    /**
+     * `[width, height]` in millimetres, both `> 0`, or `null` when unknown.
+     * When `null`, model-plane units are level-0 pixels (§3).
+     */
+    readonly physicalSizeMm: readonly [number, number] | null;
+}
+
+/**
+ * Geometry of the image pyramid the target was trained on (§5.4).
+ *
+ * `levelSizes` is authoritative and never recomputed from `scaleStep`:
+ * implementations round differently, so sizes are recorded as produced.
+ */
+export interface PyramidInfo {
+    /** Size ratio between consecutive levels, e.g. `2^(1/3)`. Finite and `> 1`. */
+    readonly scaleStep: number;
+    /** `[width, height]` per level, level 0 first. Its length is `L`. */
+    readonly levelSizes: readonly (readonly [number, number])[];
+}
+
+/** Which detector produced the keypoints, and how (§5.5). Informative. */
+export interface DetectorInfo {
+    readonly kind: Known<DetectorKind>;
+    readonly params: Params;
+}
+
+/**
+ * Keypoints as a structure of arrays (§5.5), `N = count` entries each.
+ *
+ * Structure-of-arrays rather than an array of objects: it is what the file
+ * stores, it keeps the decode a set of typed-array views instead of `N` object
+ * allocations, and it is the fixed-shape data ADR-0001 point 7 asks for.
+ *
+ * Keypoints are sorted by level, ascending.
+ *
+ * Coordinates are `Float32Array`, not `Float64Array`: §5.5 stores them as
+ * `f32` because that halves the arrays and is still far below detector
+ * accuracy. Readers widen to `Float64` when building the contract's
+ * `PointArray` — ADR-0001 point 7's float64 rule governs computed geometry,
+ * not this storage.
+ */
+export interface KeypointTable {
+    /** `N`. */
+    readonly count: number;
+    readonly detector: DetectorInfo;
+    /**
+     * `L + 1` entries: the keypoints of level `l` are the indices
+     * `[levelStart[l], levelStart[l + 1])`, and `levelStart[L] = N`.
+     */
+    readonly levelStart: Uint32Array;
+    /** Level-0 coordinates (§3), `N` entries. */
+    readonly x: Float32Array;
+    /** Level-0 coordinates (§3), `N` entries. */
+    readonly y: Float32Array;
+    /** Radians, as the detector produced them; no range is guaranteed. */
+    readonly angle: Float32Array;
+    /** Detector response. */
+    readonly score: Float32Array;
+    /**
+     * Diameter, in level-0 pixels, of the region the descriptor sampled.
+     * Absent when the producer did not record it.
+     */
+    readonly size?: Float32Array;
+    /** Pyramid level per keypoint; agrees with {@link levelStart}. */
+    readonly level: Uint8Array;
+}
+
+/**
+ * Fields shared by every descriptor set (§5.6).
+ *
+ * `count`, `bytesPerDescriptor`, `kind` and `norm` are named exactly as in the
+ * contract's `Descriptors` on purpose: a per-level slice of a binary set is
+ * then a `subarray` view plus these fields, and the descriptor bytes are
+ * never copied or converted.
+ *
+ * The names line up; the *types* of `kind` and `norm` deliberately do not.
+ * They are open unions here (§5.6 requires an unknown family to stay
+ * representable), so they do not assign to the contract's closed
+ * `DescriptorKind`/`DescriptorNorm` on their own. What narrows them is the
+ * §6.3 usability check — a set is consumable only when `elementType` is
+ * `"bits"`, `norm` is `"hamming"` and `kind` is one the backend declares.
+ * That guard belongs to the codec and lands with it; it is not a conversion
+ * of the data.
+ */
+interface DescriptorSetBase {
+    readonly kind: Known<DescriptorKind>;
+    readonly norm: Known<DescriptorNorm>;
+    /** Number of bits for `"bits"`, number of elements otherwise. */
+    readonly dimensions: number;
+    /**
+     * `dimensions / 8` for `"bits"`, `dimensions` for `"u8"`,
+     * `4 × dimensions` for `"f32"`.
+     */
+    readonly bytesPerDescriptor: number;
+    /** `capabilities.name` of the backend that computed the set. */
+    readonly producer: string;
+    readonly params: Params;
+    /** Rows, `M`. */
+    readonly count: number;
+    /**
+     * `L + 1` entries: the rows of level `l` are `[levelStart[l],
+     * levelStart[l + 1])`, `levelStart[0] = 0` and `levelStart[L] = M`.
+     */
+    readonly levelStart: Uint32Array;
+    /**
+     * `M` entries: the keypoint each row describes. Every row in the range of
+     * level `l` references a keypoint whose level is `l`. Several rows may
+     * describe the same keypoint only under the `WKNF_multiview` extension.
+     */
+    readonly kpIndex: Uint32Array;
+}
+
+/**
+ * Packed binary descriptors — the only form the current contract can consume
+ * (§6.3), since `Descriptors.data` is a `Uint8Array` and every
+ * `DescriptorKind` defined today is binary.
+ */
+export interface BitsDescriptorSet extends DescriptorSetBase {
+    readonly elementType: "bits";
+    /** `M × bytesPerDescriptor` bytes, row-major. */
+    readonly data: Uint8Array;
+}
+
+/** Byte-valued descriptors, one byte per dimension. */
+export interface U8DescriptorSet extends DescriptorSetBase {
+    readonly elementType: "u8";
+    /** `M × bytesPerDescriptor` bytes, row-major. */
+    readonly data: Uint8Array;
+}
+
+/** Float descriptors, e.g. for a future float family. */
+export interface F32DescriptorSet extends DescriptorSetBase {
+    readonly elementType: "f32";
+    /** `M × dimensions` floats, row-major. */
+    readonly data: Float32Array;
+}
+
+/**
+ * One descriptor set (§5.6), discriminated by `elementType`.
+ *
+ * The discriminant carries the element array with it, so narrowing on
+ * `elementType` yields the right typed array, and §6.3's usability rule —
+ * only `"bits"` + `"hamming"` is consumable today — is a type guard rather
+ * than a comment.
+ */
+export type DescriptorSet =
+    | BitsDescriptorSet
+    | U8DescriptorSet
+    | F32DescriptorSet;
+
+/**
+ * Tracking patches (§5.7), `Q = count` entries.
+ *
+ * `left`/`top` are **level** coordinates, not level-0: the pixels are read
+ * from `level[q]`'s image at exactly those integer indices (§3). These are
+ * the only positions in a target that are not in level-0 coordinates.
+ *
+ * Pixels carry no extra smoothing; blur is a tracker runtime parameter.
+ */
+export interface PatchTable {
+    /** `P`, the patch edge in pixels. */
+    readonly patchSize: number;
+    /** `Q`. */
+    readonly count: number;
+    /** Shi–Tomasi minimum eigenvalue. */
+    readonly score: Float32Array;
+    /** Top-left pixel, in the coordinates of the patch's own level. */
+    readonly left: Uint16Array;
+    /** Top-left pixel, in the coordinates of the patch's own level. */
+    readonly top: Uint16Array;
+    /** Pyramid level the patch was cut from. */
+    readonly level: Uint8Array;
+    /** `Q × P × P` grayscale values, row-major, `P × P` per patch. */
+    readonly pixels: Uint8Array;
+}
+
+/**
+ * The optional stored reference image (§5.8).
+ *
+ * Optional because of its size; it enables re-compilation, debugging and
+ * dense refinement.
+ */
+export interface ReferenceImage {
+    /** Pyramid level this image is of. */
+    readonly level: number;
+    /** Equals `pyramid.levelSizes[level][0]`. */
+    readonly width: number;
+    /** Equals `pyramid.levelSizes[level][1]`. */
+    readonly height: number;
+    /** `width × height` grayscale values, row-major. */
+    readonly pixels: Uint8Array;
+}
+
+/**
+ * Free-form provenance (§5.9). No field is required, and readers must not
+ * depend on any of them; the named ones are what the specification suggests.
+ */
+export interface TargetInfo {
+    readonly name?: string;
+    /** ISO 8601. */
+    readonly createdAt?: string;
+    readonly compiler?: Params;
+    readonly trackability?: number;
+    readonly [key: string]: unknown;
+}
+
+/**
+ * A decoded NFT target: everything the tracker needs to find and follow one
+ * planar image.
+ *
+ * Mirrors the manifest's top level (§5.1) minus the framing: `accessors` is
+ * gone, and each field that referenced an accessor holds the typed array
+ * itself.
+ */
+export interface TargetDb {
+    /** `"MAJOR.MINOR"` as stored (§5.1). Interpreting it is the codec's job (§7). */
+    readonly formatVersion: string;
+    /** Free text identifying what wrote the file. */
+    readonly generator?: string;
+    /** Names of extensions present in the file. */
+    readonly extensionsUsed: readonly string[];
+    /**
+     * Subset of {@link extensionsUsed} a reader must understand to read the
+     * file correctly. `WKNF_multiview` here is what permits `M ≠ N` in a
+     * descriptor set (§5.6).
+     */
+    readonly extensionsRequired: readonly string[];
+    /** Top-level extension payloads, keyed by extension name (§5.1). */
+    readonly extensions?: Readonly<Record<string, unknown>>;
+    readonly meta: TargetMeta;
+    readonly pyramid: PyramidInfo;
+    readonly keypoints: KeypointTable;
+    /** At least one entry (§5.1). Usability is decided per set (§6.3). */
+    readonly descriptorSets: readonly DescriptorSet[];
+    readonly patches?: PatchTable;
+    readonly referenceImage?: ReferenceImage;
+    readonly info?: TargetInfo;
+}

--- a/packages/nft-tracker/src/target/types.ts
+++ b/packages/nft-tracker/src/target/types.ts
@@ -79,8 +79,32 @@ import type {
  */
 type Known<T extends string> = T | (string & {});
 
-/** Free-form, implementation-defined parameters (§5.5, §5.6, §5.9). */
-export type Params = Readonly<Record<string, unknown>>;
+/**
+ * Any value a JSON manifest can hold.
+ *
+ * `params` and `info` are the two places the specification hands the file
+ * arbitrary content (§5.5, §5.6, §5.9). They are *data*, not unrecognised
+ * keys: §7.3 discards what a decoder does not understand, but these two are
+ * specified to carry anything, so carrying them through unchanged is what
+ * understanding them means. Typing them as JSON rather than `unknown` says
+ * that much, and keeps them serialisable by construction.
+ */
+export type JsonValue =
+    | string
+    | number
+    | boolean
+    | null
+    | readonly JsonValue[]
+    | { readonly [key: string]: JsonValue };
+
+/**
+ * Free-form, implementation-defined parameters (§5.5, §5.6).
+ *
+ * Always present in memory. The key is optional in the file and the canonical
+ * writer omits it when empty (§7.3), so a decoder substitutes `{}` and an
+ * encoder drops it again — the absence and `{}` are the same target.
+ */
+export type Params = Readonly<Record<string, JsonValue>>;
 
 /**
  * Physical and pixel size of the target (§5.3).
@@ -294,7 +318,7 @@ export interface TargetInfo {
     readonly createdAt?: string;
     readonly compiler?: Params;
     readonly trackability?: number;
-    readonly [key: string]: unknown;
+    readonly [key: string]: JsonValue | undefined;
 }
 
 /**
@@ -310,7 +334,20 @@ export interface TargetDb {
     readonly formatVersion: string;
     /** Free text identifying what wrote the file. */
     readonly generator?: string;
-    /** Names of extensions present in the file. */
+    /**
+     * Names of extensions present in the file. Empty when the file declares
+     * none: the key is omitted by the canonical writer when empty (§7.3), and
+     * an absent one decodes to `[]`.
+     *
+     * There is deliberately **no generic payload bag** beside these names. A
+     * required extension a reader does not implement is rejected outright
+     * (§6.1 step 5), and an unknown non-required one is ignored on decode and
+     * not re-emitted (§7.3) — so every payload that survives decoding belongs
+     * to an extension this package implements, and gets an explicit, typed
+     * field when it does. `WKNF_multiview` is the first such case (milestone
+     * M4). A `Record<string, unknown>` here would promise to preserve exactly
+     * the content §7.3 says is dropped.
+     */
     readonly extensionsUsed: readonly string[];
     /**
      * Subset of {@link extensionsUsed} a reader must understand to read the
@@ -318,8 +355,6 @@ export interface TargetDb {
      * descriptor set (§5.6).
      */
     readonly extensionsRequired: readonly string[];
-    /** Top-level extension payloads, keyed by extension name (§5.1). */
-    readonly extensions?: Readonly<Record<string, unknown>>;
     readonly meta: TargetMeta;
     readonly pyramid: PyramidInfo;
     readonly keypoints: KeypointTable;

--- a/packages/nft-tracker/src/target/types.ts
+++ b/packages/nft-tracker/src/target/types.ts
@@ -259,6 +259,20 @@ export interface F32DescriptorSet extends DescriptorSetBase {
  * `elementType` yields the right typed array, and §6.3's usability rule —
  * only `"bits"` + `"hamming"` is consumable today — is a type guard rather
  * than a comment.
+ *
+ * **Why this union is closed while `kind` and `norm` are open.** §5.6 treats
+ * the three unknowns differently, because `elementType` is what says how to
+ * read the bytes:
+ *
+ * - An unknown `kind` or `norm` with a known `elementType` leaves the set
+ *   structurally understood — element width, row count and `kpIndex` all
+ *   readable — so it is preserved and re-emitted unchanged. It is unusable
+ *   and warned about, and the open unions above are what let it exist here.
+ * - An unknown `elementType` leaves nothing interpretable: neither the
+ *   element width nor the accessor type to expect. Such a set is **dropped on
+ *   decode** with the same warning, so it never reaches these types — which
+ *   is why a fourth, "unknown" variant would be unreachable rather than
+ *   useful.
  */
 export type DescriptorSet =
     | BitsDescriptorSet
@@ -335,9 +349,13 @@ export interface TargetDb {
     /** Free text identifying what wrote the file. */
     readonly generator?: string;
     /**
-     * Names of extensions present in the file. Empty when the file declares
-     * none: the key is omitted by the canonical writer when empty (§7.3), and
-     * an absent one decodes to `[]`.
+     * Names of the extensions **this implementation understands** that the
+     * file declares — not necessarily what the file's own `extensionsUsed`
+     * listed. An unknown non-required extension is ignored on decode and its
+     * name is pruned from this array, so re-encoding does not advertise a
+     * payload that is no longer there (§7.3). Empty when nothing is left: the
+     * key is omitted by the canonical writer when empty, and an absent one
+     * decodes to `[]`.
      *
      * There is deliberately **no generic payload bag** beside these names. A
      * required extension a reader does not implement is rejected outright

--- a/packages/nft-tracker/test/types.test.ts
+++ b/packages/nft-tracker/test/types.test.ts
@@ -1,0 +1,259 @@
+/*
+ *  types.test.ts
+ *  nft-tracker
+ *
+ *  This file is part of nft-tracker - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  nft-tracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  nft-tracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with nft-tracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *             Thorsten Bux @ThorstenBux https://github.com/ThorstenBux
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Descriptors } from "@webarkit/cv-backend-spec";
+import type { DescriptorSet, TargetDb } from "../src/index";
+
+/**
+ * The package has no behaviour yet — these types *are* the deliverable, and
+ * the point of this suite is that a target built the way the specification
+ * describes one type-checks against them.
+ *
+ * `npm run typecheck` is therefore the real assertion: it compiles this file
+ * against `tsconfig.test.json`, so a type that cannot express a legal target
+ * fails there. The runtime expectations below pin the array-length invariants
+ * the literal claims, so that a wrong fixture cannot quietly stand in as
+ * evidence that the types are right.
+ */
+
+// A 2-level, 4-keypoint target: the smallest thing that still exercises
+// per-level ranges, a descriptor set and patches.
+const L = 2;
+const N = 4;
+const M = 4;
+const BYTES_PER_DESCRIPTOR = 32; // 256-bit ORB
+const P = 8;
+const Q = 2;
+
+const target: TargetDb = {
+    formatVersion: "0.1",
+    generator: "@webarkit/nft-tracker 0.0.0",
+    extensionsUsed: [],
+    extensionsRequired: [],
+    meta: {
+        widthPx: 64,
+        heightPx: 48,
+        physicalSizeMm: [80, 60],
+    },
+    pyramid: {
+        scaleStep: Math.cbrt(2),
+        levelSizes: [
+            [64, 48],
+            [50, 38],
+        ],
+    },
+    keypoints: {
+        count: N,
+        detector: { kind: "fast", params: { threshold: 20 } },
+        // 3 keypoints on level 0, 1 on level 1.
+        levelStart: Uint32Array.from([0, 3, N]),
+        x: Float32Array.from([10, 20, 30, 12.5]),
+        y: Float32Array.from([11, 21, 31, 13.5]),
+        angle: Float32Array.from([0, 1.2, -0.4, 2.9]),
+        score: Float32Array.from([31, 44, 22, 19]),
+        level: Uint8Array.from([0, 0, 0, 1]),
+    },
+    descriptorSets: [
+        {
+            kind: "orb",
+            norm: "hamming",
+            elementType: "bits",
+            dimensions: 256,
+            bytesPerDescriptor: BYTES_PER_DESCRIPTOR,
+            producer: "jsfeatnext",
+            params: { wtaK: 2 },
+            count: M,
+            levelStart: Uint32Array.from([0, 3, M]),
+            kpIndex: Uint32Array.from([0, 1, 2, 3]),
+            data: new Uint8Array(M * BYTES_PER_DESCRIPTOR),
+        },
+    ],
+    patches: {
+        patchSize: P,
+        count: Q,
+        score: Float32Array.from([0.6, 0.4]),
+        left: Uint16Array.from([4, 8]),
+        top: Uint16Array.from([5, 9]),
+        level: Uint8Array.from([0, 1]),
+        pixels: new Uint8Array(Q * P * P),
+    },
+    referenceImage: {
+        level: 0,
+        width: 64,
+        height: 48,
+        pixels: new Uint8Array(64 * 48),
+    },
+    info: { name: "fixture", trackability: 0.5 },
+};
+
+describe("TargetDb", () => {
+    it("holds the level ranges the specification requires", () => {
+        // §5.5: L + 1 entries, last one equal to N.
+        expect(target.keypoints.levelStart.length).toBe(L + 1);
+        expect(target.keypoints.levelStart[L]).toBe(N);
+        expect(target.pyramid.levelSizes.length).toBe(L);
+
+        // §5.6: levelStart[0] = 0, levelStart[L] = M, one kpIndex per row.
+        const set = target.descriptorSets[0]!;
+        expect(set.levelStart[0]).toBe(0);
+        expect(set.levelStart[L]).toBe(M);
+        expect(set.kpIndex.length).toBe(M);
+    });
+
+    it("sizes its bulk arrays as the specification prescribes", () => {
+        const set = target.descriptorSets[0]!;
+        expect(set.data.length).toBe(M * set.bytesPerDescriptor);
+
+        const patches = target.patches!;
+        expect(patches.pixels.length).toBe(patches.count * P * P);
+
+        const image = target.referenceImage!;
+        expect(image.pixels.length).toBe(image.width * image.height);
+    });
+
+    it("narrows a descriptor set on elementType", () => {
+        const set: DescriptorSet = target.descriptorSets[0]!;
+
+        if (set.elementType === "f32") {
+            // Unreachable for this fixture; present so the narrowing itself is
+            // type-checked in both directions.
+            expectTypeIsFloat32(set.data);
+            return;
+        }
+
+        // Narrowed to Uint8Array by the discriminant alone.
+        expectTypeIsUint8(set.data);
+        expect(set.data).toBeInstanceOf(Uint8Array);
+    });
+
+    it("yields a stored set that satisfies the contract's Descriptors", () => {
+        const set = target.descriptorSets[0]!;
+        expect(set.elementType).toBe("bits");
+        expect(set.norm).toBe("hamming");
+        if (set.elementType !== "bits") return; // narrowing, already asserted
+
+        // §6.3: only bits + hamming is consumable today. The field names line
+        // up with Descriptors, so the descriptor bytes go across as a view,
+        // with no copy and no conversion — that much this assignment does
+        // show at compile time.
+        //
+        // What it does NOT show is that `kind` and `norm` carry over on their
+        // own: they are open unions here (§5.6 keeps an unknown family
+        // representable), so they do not assign to the contract's closed
+        // unions. Narrowing them is the job of the §6.3 usability guard, which
+        // arrives with the codec; until then the fixture states them
+        // literally, and that literal is the gap, not a proof.
+        const descriptors: Descriptors = {
+            data: set.data,
+            count: set.count,
+            bytesPerDescriptor: set.bytesPerDescriptor,
+            kind: "orb",
+            norm: "hamming",
+        };
+
+        expect(descriptors.count).toBe(M);
+        expect(descriptors.data.length).toBe(M * BYTES_PER_DESCRIPTOR);
+    });
+
+    it("accepts a target without the optional sections", () => {
+        const minimal: TargetDb = {
+            formatVersion: "0.1",
+            extensionsUsed: [],
+            extensionsRequired: [],
+            meta: { widthPx: 8, heightPx: 8, physicalSizeMm: null },
+            pyramid: { scaleStep: 2, levelSizes: [[8, 8]] },
+            keypoints: {
+                count: 0,
+                detector: { kind: "fast", params: {} },
+                levelStart: Uint32Array.from([0, 0]),
+                x: new Float32Array(0),
+                y: new Float32Array(0),
+                angle: new Float32Array(0),
+                score: new Float32Array(0),
+                level: new Uint8Array(0),
+            },
+            descriptorSets: [
+                {
+                    kind: "orb",
+                    norm: "hamming",
+                    elementType: "bits",
+                    dimensions: 256,
+                    bytesPerDescriptor: BYTES_PER_DESCRIPTOR,
+                    producer: "jsfeatnext",
+                    params: {},
+                    count: 0,
+                    levelStart: Uint32Array.from([0, 0]),
+                    kpIndex: new Uint32Array(0),
+                    data: new Uint8Array(0),
+                },
+            ],
+        };
+
+        expect(minimal.patches).toBeUndefined();
+        expect(minimal.referenceImage).toBeUndefined();
+        expect(minimal.info).toBeUndefined();
+        expect(minimal.meta.physicalSizeMm).toBeNull();
+    });
+
+    it("can hold a set whose family the contract does not enumerate", () => {
+        // §5.6: an unknown kind or norm must stay representable, so that the
+        // reader can mark it unusable and keep the rest of the file working.
+        const exotic: DescriptorSet = {
+            kind: "some-future-family",
+            norm: "hamming2",
+            elementType: "f32",
+            dimensions: 64,
+            bytesPerDescriptor: 4 * 64,
+            producer: "purecv",
+            params: {},
+            count: 1,
+            levelStart: Uint32Array.from([0, 1]),
+            kpIndex: Uint32Array.from([0]),
+            data: new Float32Array(64),
+        };
+
+        expect(exotic.data).toBeInstanceOf(Float32Array);
+        expect(exotic.data.length).toBe(exotic.dimensions * exotic.count);
+    });
+});
+
+/** Compile-time assertions: these fail to typecheck if narrowing regresses. */
+function expectTypeIsUint8(_value: Uint8Array): void {}
+function expectTypeIsFloat32(_value: Float32Array): void {}

--- a/packages/nft-tracker/tsconfig.json
+++ b/packages/nft-tracker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/nft-tracker/tsconfig.test.json
+++ b/packages/nft-tracker/tsconfig.test.json
@@ -1,0 +1,54 @@
+/*
+ *  tsconfig.test.json
+ *  nft-tracker
+ *
+ *  This file is part of nft-tracker - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  nft-tracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  nft-tracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with nft-tracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *             Thorsten Bux @ThorstenBux https://github.com/ThorstenBux
+ *
+ */
+
+{
+  // Type-checks the test suite, which the build tsconfig deliberately excludes
+  // (tests must not land in dist/). Vitest transpiles without type-checking, so
+  // without this the target types could drift out of agreement with the very
+  // fixtures that exist to pin them down, and still pass.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The base sets rootDir to ./src so the build emits a flat dist/. Nothing
+    // is emitted here, so widen it to take test/ into the program too.
+    "rootDir": ".",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Implements action item 3 of [ADR-0001](https://github.com/webarkit/webarkit/blob/dev/docs/adr/0001-nft-tracker-ts-reference-above-cvbackend.md), and carries an editorial revision of the target format spec that came out of reviewing it.

## What

The `packages/nft-tracker` workspace and the **in-memory** types of a decoded NFT target. This is the contract-first step: both flows of the next milestone — the target **compiler**, which produces a target, and the **codec**, which decodes one from bytes and encodes it back — depend on the same shape, so that shape is written and reviewed before either is built.

**No logic, no codec, no tracker.** Accessors, chunks, byte offsets, padding and CRC-32 are framing concerns of the codec (spec §4, §5.2) and deliberately do not appear here — a consumer of a `TargetDb` never needs to know it came from a file.

`TargetDb` mirrors the manifest's top level (§5.1) minus that framing: `TargetMeta` (§5.3), `PyramidInfo` (§5.4), `KeypointTable` (§5.5), `DescriptorSet` (§5.6), `PatchTable` (§5.7), `ReferenceImage` (§5.8), `TargetInfo` (§5.9). Keypoints and patches are structures of arrays in the typed-array widths the spec prescribes — `u32` level ranges, `u8` levels, `u16` patch corners, `f32` coordinates and scores.

## Spec: format 0.1 rev 2 (editorial)

Reviewing the types raised three questions the spec did not answer: must a decoder preserve unknown top-level keys, must it preserve extension payloads it does not understand, and is `params` required. All three follow from one principle, now stated in §7.3:

> A decoder keeps only what it understands, and the canonical writer emits only that.

An implementation cannot keep data it does not understand consistent — accessor renumbering alone breaks it. So unknown keys and unknown non-required extension payloads are ignored on decode and not re-emitted; empty optional objects and arrays (`params`, `extensionsUsed`, `extensionsRequired`) are omitted by the canonical writer and read back as empty; `params` is optional and an absent one equals `{}`; and `params`/`info` are *data*, not unknown keys — specified to carry arbitrary content, hence preserved as-is.

Review of that revision found four places where its own wording had not been carried through, all folded into the same rev 2 (this PR is unmerged, so rev 2 has never been released): §8.3 still said unknown keys inside `params` are ignored, contradicting §5.6; an ignored non-required extension must also be pruned from `extensionsUsed`; `params`/`info` keys need a specified sort order for the round trip to be byte-identical, and `JSON.stringify` does not produce it (`"9"` before `"10"`); and unusable descriptor sets split in two — unknown `kind`/`norm` preserved, unknown `elementType` dropped.

§8.2's byte-identical round trip is scoped accordingly, to canonical files whose content the implementation fully understands, and a new test pins the other half: a `noncanonical/` file decodes to the same values as its canonical counterpart and re-encodes to **that counterpart**, not to itself. §8.1 gains the `noncanonical/` fixture set backing it. §12 records the revision.

This changes neither the bytes nor the meaning of any valid `0.1` file, so it is a revision of `0.1` rather than a new version — the AGENTS.md rule makes accepted *ADRs* immutable, while the spec is versioned by its format version and now carries a changelog.

## Type decisions

- **Open unions** for `kind`, `norm` and the detector kind. §5.6 requires a set whose family or metric the reader does not know to stay *present but unusable*, which the contract's closed unions cannot represent. The cost, recorded in the code: `kind` and `norm` no longer assign to the contract's unions on their own — the §6.3 usability guard narrows them, and it arrives with the codec.
- **`DescriptorSet` is discriminated on `elementType`** (`"bits"` / `"u8"` / `"f32"`), so narrowing yields the right typed array and §6.3's "bits + hamming only" rule is a type guard rather than a comment.
- **`params` is `Record<string, JsonValue>`** and always present in memory; the new exported `JsonValue` says what a manifest can hold. `TargetInfo` keeps its index signature, `info` being free-form by design.
- **No generic extension payload bag.** Every payload that survives decoding belongs to an extension this package implements — required-but-unknown ones are rejected at §6.1 step 5, unknown non-required ones are dropped by §7.3 — so known extensions get explicit typed fields instead, `WKNF_multiview` first (M4). `extensionsUsed` / `extensionsRequired` stay, being what the multi-view rule is written in terms of.
- **`TargetDb` has no index signature**, per ADR-0001 point 7's fixed-shape data rule.

`f32` rather than `f64` for coordinates is §5.5's own storage rule; readers widen when building the contract's `PointArray`, and ADR-0001 point 7's float64 rule governs computed geometry, not stored target data.

## Dependency arrow

Runtime dependency is `@webarkit/cv-backend-spec` and nothing else. `cv-backend-jsfeatnext` is a devDependency and is not imported from `src/`. The package is appended to the root `build` script **after** `cv-backend-jsfeatnext`, where the order is load-bearing (AGENTS.md).

## Verification

- `npm run build` — pass, in order: spec → jsfeatnext → nft-tracker
- `npm run typecheck` — pass, all three workspaces
- `npm test` — pass, 30 + 13 + 6
- Negative control: a deliberate type error in `test/` makes `npm run typecheck` fail (`TS2740`) and pass again once reverted, confirming `tsconfig.test.json` really covers the suite
- Dependency arrow checked by grep: no jsfeatNext or backend import anywhere under `src/`
- Relative links in the ADR and the spec all resolve

## Review

Reviewed by the `nft-reviewer` subagent against ADR-0001, the format spec and AGENTS.md: nothing blocking. Its substantive finding — a doc comment and a test comment that overclaimed compile-time `Descriptors` compatibility — is fixed here.

**The three follow-ups this PR originally listed are now resolved** by spec 0.1 rev 2 and the type alignment above: `params` optionality, unknown top-level keys, and nested extension payloads all answered by §7.3's single principle. Qodo raised the same two points independently; both are covered.

### Resolved since opening

**Unknown `elementType`**, which this PR originally carried as open, is settled by rev 2: an unknown `kind` or `norm` with a known `elementType` leaves a set structurally understood, so it is preserved and re-emitted (unusable, warned); an unknown `elementType` leaves nothing interpretable and is dropped on decode with the same warning. Since such a set never survives decoding, it never reaches `DescriptorSet` — the closed discriminant is correct and a fourth "unknown" variant would be unreachable.

`Q10` is added to the spec's open questions: whether to require the manifest to be I-JSON (RFC 7493). Without it, two conforming decoders can read the same untrusted file differently, since `JSON.parse` keeps the last of duplicate keys. To decide before the TS codec, not before this merge.

## Docs

The root README described a two-package repository in five places (package table, publish note, install prose, build-order comment, layout tree) plus the "premature at two packages" argument for not adopting Turborepo/Nx. All six now match reality; the Turborepo conclusion is unchanged. ADR-0001 action item 3 is ticked — a status checkbox, not a change to the decision the ADR records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
